### PR TITLE
Feature: immediate send-time coaching and AI copy-trace alerts

### DIFF
--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.4
+
+- added immediate prompt analysis on send-button click across supported AI chat UIs
+- improved send-time responsiveness by decoupling coach feedback from stats write latency
+- added long AI-output copy tracking and warning when pasted back into composer
+
 ## v1.2.3
 
 - added production validator script for extension package integrity

--- a/docs/08-product/feature-spec.md
+++ b/docs/08-product/feature-spec.md
@@ -41,6 +41,11 @@ Analyzes each submitted prompt for:
 
 Outputs a quality score and targeted feedback.
 
+Trigger behavior:
+
+- run immediately when user presses `Enter`
+- run immediately when user clicks AI platform send/submit button
+
 ## 4. Habit and Dependency Coaching
 
 Tracks local counters:
@@ -54,6 +59,8 @@ Displays warning when dependency exceeds configured threshold.
 ## 5. Copy-Paste Risk Alerts
 
 When large multi-line code pastes are detected, the user gets coaching prompts to review and test before using pasted code.
+
+If a user copies long AI-generated output and pastes it back into a prompt composer, the extension warns them to rewrite with their own reasoning before sending.
 
 ## 6. Settings and Controls
 

--- a/docs/08-product/user-flow.md
+++ b/docs/08-product/user-flow.md
@@ -20,9 +20,20 @@
 3. Overlay provides warnings or suggestions.
 4. Stats are updated in local storage.
 
+Submission signals:
+
+- Enter key in prompt composer
+- Send/Submit button click
+
 ## Risk Event: Large Paste
 
 1. User pastes large code block.
 2. Extension detects code-like paste content.
 3. Warning asks user to explain and test before usage.
 4. Repeated behavior triggers stronger pattern alert.
+
+## Risk Event: Copy AI Output then Reuse
+
+1. User copies a long assistant response.
+2. User pastes that content into a prompt composer.
+3. Extension warns user to rewrite with personal reasoning and verification steps before sending.

--- a/extension/content/interactionTracker.js
+++ b/extension/content/interactionTracker.js
@@ -12,7 +12,14 @@
   };
 
   const WARNING_COOLDOWN_MS = 3000;
+  const LONG_COPY_THRESHOLD = 360;
+  const COPY_TRACE_TTL_MS = 8 * 60 * 1000;
   let lastWarningAt = 0;
+  let recentAiCopy = {
+    at: 0,
+    signature: "",
+    chars: 0
+  };
 
   function storageGet(keys) {
     return new Promise((resolve) => chrome.storage.local.get(keys, resolve));
@@ -20,6 +27,15 @@
 
   function storageSet(payload) {
     return new Promise((resolve) => chrome.storage.local.set(payload, resolve));
+  }
+
+  function normalizeText(text) {
+    return (text || "").replace(/\s+/g, " ").trim();
+  }
+
+  function buildTextSignature(text) {
+    const normalized = normalizeText(text);
+    return `${normalized.length}:${normalized.slice(0, 90)}:${normalized.slice(-50)}`;
   }
 
   function looksLikeCode(text) {
@@ -32,6 +48,24 @@
     const codeSignals = [/[{};]/, /function\s+\w+/i, /const\s+\w+\s*=/, /class\s+\w+/i, /=>/, /import\s+.+from\s+/i];
 
     return hasMultiLine && codeSignals.some((pattern) => pattern.test(text));
+  }
+
+  function hasLargeCopiedAiOutput(text) {
+    if (!text || text.length < LONG_COPY_THRESHOLD) {
+      return false;
+    }
+
+    if (!recentAiCopy.signature || !recentAiCopy.at) {
+      return false;
+    }
+
+    if (Date.now() - recentAiCopy.at > COPY_TRACE_TTL_MS) {
+      return false;
+    }
+
+    const sameSignature = buildTextSignature(text) === recentAiCopy.signature;
+    const similarLength = Math.abs(text.length - recentAiCopy.chars) <= 24;
+    return sameSignature || similarLength;
   }
 
   function showWarning(message, settings, options = {}) {
@@ -85,6 +119,44 @@
     );
   }
 
+  function isLikelyAssistantOutputSelection(target) {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    if (isEditableTarget(target)) {
+      return false;
+    }
+
+    if (target.closest("form,[data-testid*='composer'],[class*='composer']")) {
+      return false;
+    }
+
+    const assistantMarkers = [
+      "[data-message-author-role='assistant']",
+      "[data-author='assistant']",
+      "[data-role='assistant']",
+      "[data-testid*='assistant']",
+      "[class*='assistant']",
+      "[class*='response']"
+    ];
+
+    if (assistantMarkers.some((selector) => !!target.closest(selector))) {
+      return true;
+    }
+
+    // Fallback: on AI chat pages, long copies from non-editable regions are typically model output.
+    return true;
+  }
+
+  function rememberAiCopy(text) {
+    recentAiCopy = {
+      at: Date.now(),
+      signature: buildTextSignature(text),
+      chars: text.length
+    };
+  }
+
   async function incrementLargePasteCount() {
     const data = await storageGet(["stats"]);
     const stats = { ...DEFAULT_STATS, ...(data.stats || {}) };
@@ -93,6 +165,32 @@
     await storageSet({ stats });
     return stats.largePastes;
   }
+
+  document.addEventListener(
+    "copy",
+    (event) => {
+      const selectedText = normalizeText(window.getSelection()?.toString() || "");
+      if (!selectedText || selectedText.length < LONG_COPY_THRESHOLD) {
+        return;
+      }
+
+      const sourceElement =
+        event.target instanceof HTMLElement
+          ? event.target
+          : window.getSelection()?.anchorNode?.parentElement;
+
+      if (!(sourceElement instanceof HTMLElement)) {
+        return;
+      }
+
+      if (!isLikelyAssistantOutputSelection(sourceElement)) {
+        return;
+      }
+
+      rememberAiCopy(selectedText);
+    },
+    true
+  );
 
   document.addEventListener("paste", async (event) => {
     if (!isEditableTarget(event.target)) {
@@ -113,16 +211,37 @@
       return;
     }
 
-    if (pastedText.length < settings.pasteThreshold || !looksLikeCode(pastedText)) {
+    const isLargePaste = pastedText.length >= settings.pasteThreshold;
+    if (!isLargePaste) {
+      return;
+    }
+
+    const pastedCopiedAiOutput = hasLargeCopiedAiOutput(pastedText);
+    const pastedCode = looksLikeCode(pastedText);
+
+    if (!pastedCopiedAiOutput && !pastedCode) {
       return;
     }
 
     const largePasteCount = await incrementLargePasteCount();
 
-    showWarning(
-      "Large code paste detected. Read, explain, and test the snippet before using it.",
-      settings
-    );
+    if (pastedCopiedAiOutput) {
+      showWarning(
+        "You pasted a long AI answer. Pause and rewrite it in your own words before sending.",
+        settings
+      );
+
+      showWarning(
+        "Before send: add your reasoning, assumptions, and one verification step.",
+        settings,
+        { force: true }
+      );
+    } else {
+      showWarning(
+        "Large code paste detected. Read, explain, and test the snippet before using it.",
+        settings
+      );
+    }
 
     if (largePasteCount >= 3) {
       showWarning(

--- a/extension/content/monitor.js
+++ b/extension/content/monitor.js
@@ -67,6 +67,24 @@
     /copy and paste/i,
     /urgent.*fix/i
   ];
+  const SEND_BUTTON_HINTS = [
+    /\bsend\b/i,
+    /\bsubmit\b/i,
+    /\bask\b/i,
+    /send message/i,
+    /submit prompt/i,
+    /arrow up/i
+  ];
+  const NON_SEND_BUTTON_HINTS = [
+    /\bstop\b/i,
+    /\bregenerate\b/i,
+    /\bretry\b/i,
+    /\bnew chat\b/i,
+    /\battach\b/i,
+    /\bupload\b/i,
+    /\bcopy\b/i,
+    /\bshare\b/i
+  ];
 
   const attachedInputs = new WeakSet();
   const attachedForms = new WeakSet();
@@ -168,6 +186,22 @@
     }
 
     return matches;
+  }
+
+  function findVisibleInputInScope(scope, platform) {
+    if (!scope || !(scope instanceof Element)) {
+      return null;
+    }
+
+    for (const selector of platform.inputSelectors) {
+      const candidates = Array.from(scope.querySelectorAll(selector));
+      const visible = candidates.find((candidate) => candidate instanceof HTMLElement && isVisibleInput(candidate));
+      if (visible) {
+        return visible;
+      }
+    }
+
+    return null;
   }
 
   function readPrompt(input) {
@@ -372,9 +406,10 @@
 
     const { settings, profile } = await getState();
     const analysis = analyzePrompt(prompt, settings.strictMode);
-    const { dependency } = await updatePromptStats(prompt);
+    const statsPromise = updatePromptStats(prompt);
 
     if (!settings.enableCoach) {
+      await statsPromise;
       return;
     }
 
@@ -393,21 +428,88 @@
       text: `Prompt quality score: ${analysis.score}/100 (Grade ${analysis.grade})`
     });
 
-    if (dependency >= settings.dependencyWarningThreshold) {
-      messages.push({
-        type: "warning",
-        text: `AI dependency is ${dependency}%. Try one manual debugging pass first.`
-      });
-    }
-
     const habitTip = buildHabitTip(profile, analysis);
     messages.push({ type: "info", text: habitTip });
 
     queueMessages(messages, settings);
+
+    const { dependency } = await statsPromise;
+    if (dependency >= settings.dependencyWarningThreshold) {
+      showCoachMessage(
+        `AI dependency is ${dependency}%. Try one manual debugging pass first.`,
+        "warning",
+        settings
+      );
+    }
   }
 
   function shouldTrackEnter(event) {
     return event.key === "Enter" && !event.shiftKey && !event.isComposing;
+  }
+
+  function isLikelySendButton(element) {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+
+    if (element.matches("button[type='submit'],input[type='submit']")) {
+      return true;
+    }
+
+    const attributes = [
+      element.getAttribute("aria-label"),
+      element.getAttribute("title"),
+      element.getAttribute("data-testid"),
+      element.getAttribute("name"),
+      element.id,
+      element.textContent
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    if (!attributes) {
+      return false;
+    }
+
+    if (NON_SEND_BUTTON_HINTS.some((pattern) => pattern.test(attributes))) {
+      return false;
+    }
+
+    return SEND_BUTTON_HINTS.some((pattern) => pattern.test(attributes));
+  }
+
+  function resolvePromptInputFromTrigger(trigger, platform) {
+    if (!(trigger instanceof HTMLElement)) {
+      return null;
+    }
+
+    const form = trigger.closest("form");
+    if (form) {
+      const formInput = findVisibleInputInScope(form, platform);
+      if (formInput) {
+        return formInput;
+      }
+    }
+
+    const composer = trigger.closest("[data-testid*='composer'],[class*='composer'],[class*='prompt']");
+    if (composer) {
+      const composerInput = findVisibleInputInScope(composer, platform);
+      if (composerInput) {
+        return composerInput;
+      }
+    }
+
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement &&
+      isPlatformInput(platform, activeElement) &&
+      isVisibleInput(activeElement)
+    ) {
+      return activeElement;
+    }
+
+    const inputs = findPromptInputs(platform);
+    return inputs[0] || null;
   }
 
   function buildPromptSignature(prompt) {
@@ -507,6 +609,33 @@
     childList: true,
     subtree: true
   });
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      if (!(event.target instanceof Element)) {
+        return;
+      }
+
+      const button = event.target.closest("button,[role='button'],input[type='submit'],input[type='button']");
+      if (!(button instanceof HTMLElement) || !isLikelySendButton(button)) {
+        return;
+      }
+
+      const platform = detectPlatform();
+      if (!platform) {
+        return;
+      }
+
+      const input = resolvePromptInputFromTrigger(button, platform);
+      if (!input) {
+        return;
+      }
+
+      submitPromptFromInput(input);
+    },
+    true
+  );
 
   document.addEventListener(
     "focusin",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Dev Coach",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Coach developers to use AI with better reasoning, prompting, and coding habits.",
   "minimum_chrome_version": "114",
   "homepage_url": "https://github.com/phamhungptithcm/ai-dev-coach",


### PR DESCRIPTION
## What this adds
- immediate prompt analysis on Enter and send-button click
- stronger send-time coverage across ChatGPT/Claude/Grok-style composer buttons
- copy-trace warning flow when long AI output is copied and pasted back into prompt composer
- manifest bump to v1.2.4 and docs updates for behavior expectations

## Validation
- node scripts/validate-extension.mjs
- JS syntax checks for extension files
- python3 -m json.tool extension/manifest.json
- python3 -m mkdocs build --strict