### PR TITLE
feat(prompt): add prompt quality engine v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Validate extension package structure
         run: node scripts/validate-extension.mjs
 
+      - name: Validate prompt quality engine smoke checks
+        run: node scripts/test-prompt-quality-engine.mjs
+
       - name: Validate extension JavaScript syntax
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AI Dev Coach is designed to protect the learning loop:
 - Profile level dropdown: Student, Junior, Middle, Senior
 - In-page Live Coach bubble with realtime prompt score and habit snapshot
 - 6 prompt templates: debugging, code review, system design, refactoring, performance optimization, learning
-- Prompt scoring algorithm with grade + breakdown (`completeness`, `specificity`, `reasoning`, `learning safety`, `template fit`)
+- Prompt quality engine v2 with shared scoring across popup and live monitor (`clarity`, `context`, `specificity`, `risk guardrails`)
 - Real-time prompt quality scoring on AI chat websites (draft + submit paths)
 - Sensitive data detection and local redaction for likely secrets before prompt submission
 - Warning overlays in top-right for shortcut prompts and risky copy-paste behavior
@@ -55,6 +55,7 @@ AI Dev Coach is designed to protect the learning loop:
 
 ```bash
 node scripts/validate-extension.mjs
+node scripts/test-prompt-quality-engine.mjs
 find extension -type f -name '*.js' -print0 | xargs -0 -n1 node --check
 python3 -m mkdocs build --strict
 ```

--- a/docs/01-architecture/ai-coaching-engine.md
+++ b/docs/01-architecture/ai-coaching-engine.md
@@ -5,7 +5,9 @@ The coaching engine combines prompt analysis, habit heuristics, and dependency s
 ## Input Signals
 
 - prompt structure (`Task/Context/Attempt` style sections)
+- task clarity and vague-language detection
 - context evidence (error/failure + expected/actual + artifact such as file path/snippet/log)
+- framework and stack hints (for example React, Next.js, Spring Boot, SQL, Docker)
 - attempt quality evidence (action + result + blocker)
 - negative attempt phrases (`I didn't try`, `chua thu`, `khong thu`)
 - shortcut intent patterns (for example, asking for full copy-paste code)
@@ -20,8 +22,11 @@ The coaching engine combines prompt analysis, habit heuristics, and dependency s
 
 ## Decision Rules
 
+- calculate a shared 0-100 score across popup builder and live monitor
+- scoring dimensions: `clarity`, `context`, `specificity`, `risk guardrails`
 - missing context evidence => suggest concrete evidence gaps
 - missing attempt quality => suggest adding action/result/blocker
+- vague phrase detection => reduce clarity and risk score
 - explicit no-attempt phrase => hard warning and score penalty
 - shortcut prompt => stricter warning in strict mode
 - high dependency score => recommendation to run manual debugging first

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added prompt quality engine v2 with shared scoring between popup prompt builder and live monitoring
+- added prompt-quality smoke checks in CI to guard scoring regressions
 - added local secret detection and redaction guardrail before prompt submission
 - added sprint planning documentation with prioritized backlog estimates
 - split CI/CD so docs deploy and extension release run independently
@@ -114,13 +116,3 @@
 
 - switched docs to MkDocs Material workflow
 - aligned docs/nav for extension-focused scope
-- CI/CD and release pipeline improvements
-
-## v1.2.1
-
-- prompt builder and scoring enhancements
-- docs deployment improvements
-
-## v1.2.0
-
-- initial extension MVP release

--- a/docs/08-product/feature-spec.md
+++ b/docs/08-product/feature-spec.md
@@ -51,12 +51,14 @@ See also: [Prompt Builder System](prompt-builder-system.md)
 
 Analyzes each submitted prompt for:
 
+- task clarity and vague-language detection
 - context evidence completeness (error/failure + expected/actual + artifact)
+- framework or stack context
 - independent attempt quality (action + result + blocker)
 - negative attempt phrases (for example, \"I didn't try\", \"chua thu\") as penalties
 - shortcut intent signals
 
-Outputs a quality score and targeted feedback.
+Outputs a shared quality score and targeted feedback across both popup prompt builder and live monitoring.
 
 Trigger behavior:
 

--- a/docs/08-product/prompt-builder-system.md
+++ b/docs/08-product/prompt-builder-system.md
@@ -41,28 +41,28 @@ Level modes:
 
 The extension computes a score from 0 to 100 with these weighted dimensions:
 
-1. Completeness (0-40)
-- task quality and length
-- context quality and length
-- attempt details and blockers
-- profile context (role + skill)
+1. Clarity (0-25)
+- prompt length and task clarity
+- structured sections (`Task`, `Context`, `What You Tried`)
+- penalty for vague asks such as `fix this` or `help me`
 
-2. Specificity (0-25)
-- technical signals (error/trace/file/metric keywords)
+2. Context (0-30)
+- concrete error or failure signals
+- expected vs actual behavior
+- artifacts such as file paths, snippets, logs, endpoints, or stack traces
+- framework or stack context
+
+3. Specificity (0-30)
+- action + result + blocker evidence
 - constraints provided
 - acceptance criteria quality
-- overall prompt depth
+- measurable or role-specific signals
 
-3. Reasoning Evidence (0-20)
-- hypothesis/debug/test/analysis language
-- tradeoff and validation framing
-
-4. Learning Safety (0-15)
-- penalty for shortcut language ("give full code", "just answer")
-- bonus for coach-style language ("explain", "step-by-step")
-
-5. Template Fit (0-5)
-- checks if content vocabulary matches selected template intent
+4. Risk Guardrails (0-15)
+- penalties for shortcut language (`give me full code`, `no explanation`)
+- penalties for explicit no-attempt phrases
+- stricter deductions in strict mode
+- small bonus for coaching-oriented language (`explain`, `step-by-step`)
 
 Grade mapping:
 
@@ -107,12 +107,11 @@ Grade mapping:
 | [______________________________________________]  |
 |                                                   |
 | Prompt Score: 84/100   Grade: B                   |
-| - Completeness: 33/40                             |
-| - Specificity: 20/25                              |
-| - Reasoning Evidence: 16/20                       |
-| - Learning Safety: 11/15                          |
-| - Template Fit: 4/5                               |
-| Tips: Add benchmark and acceptance criteria        |
+| - Clarity: 21/25                                  |
+| - Context: 24/30                                  |
+| - Specificity: 25/30                              |
+| - Risk Guardrails: 14/15                          |
+| Tips: Add framework version and one regression test|
 +---------------------------------------------------+
 | Habit Snapshot                                    |
 | AI requests | Manual attempts | Dependency | Paste |
@@ -160,6 +159,7 @@ Grade mapping:
 - Negative no-attempt phrases reduce score.
 - Shortcut requests (copy-paste intent) reduce score and increase warnings.
 - Dictionaries support English and Vietnamese phrasing.
+- Popup scoring and live monitoring now use the same shared prompt-quality engine to keep results consistent.
 
 ## Current Implementation Files
 
@@ -169,3 +169,4 @@ Grade mapping:
 - `extension/content/liveCoachBubble.js`
 - `extension/content/quickBuilder.js`
 - `extension/content/monitor.js`
+- `extension/shared/promptQualityEngine.js`

--- a/extension/content/monitor.js
+++ b/extension/content/monitor.js
@@ -288,6 +288,7 @@
   let lastDraftPrompt = "";
   let lastDraftPromptAt = 0;
   let cachedSettings = { ...DEFAULT_SETTINGS };
+  let cachedProfile = { ...DEFAULT_PROFILE };
   let lastSecretBlockSignature = "";
   let lastSecretBlockAt = 0;
   let scanQueued = false;
@@ -310,6 +311,17 @@
       typeof window.AIDevCoachSecretGuard.inspectPromptForSecrets === "function"
     ) {
       return window.AIDevCoachSecretGuard;
+    }
+
+    return null;
+  }
+
+  function getPromptQualityEngine() {
+    if (
+      window.AIDevCoachPromptQualityEngine &&
+      typeof window.AIDevCoachPromptQualityEngine.calculatePromptScore === "function"
+    ) {
+      return window.AIDevCoachPromptQualityEngine;
     }
 
     return null;
@@ -349,6 +361,10 @@
     cachedSettings = mergeSettings(nextSettings);
   }
 
+  function syncCachedProfile(nextProfile) {
+    cachedProfile = { ...DEFAULT_PROFILE, ...(nextProfile || {}) };
+  }
+
   async function getCurrentSettings() {
     const data = await storageGet(["settings"]);
     const settings = mergeSettings(data.settings);
@@ -358,6 +374,8 @@
 
   async function getState() {
     const data = await storageGet(["settings", "profile", "stats"]);
+    syncCachedSettings(data.settings);
+    syncCachedProfile(data.profile);
     return {
       settings: mergeSettings(data.settings),
       profile: { ...DEFAULT_PROFILE, ...(data.profile || {}) },
@@ -756,6 +774,11 @@
   }
 
   function scoreGrade(score) {
+    const engine = getPromptQualityEngine();
+    if (engine && typeof engine.gradeFromScore === "function") {
+      return engine.gradeFromScore(score);
+    }
+
     if (score >= 90) {
       return "A";
     }
@@ -806,110 +829,33 @@
     };
   }
 
-  function analyzePrompt(prompt, strictMode) {
-    let score = 0;
-    const warnings = [];
-    const suggestions = [];
+  function analyzePrompt(prompt, strictMode, profile = DEFAULT_PROFILE) {
+    const engine = getPromptQualityEngine();
+    if (!engine) {
+      return {
+        score: 0,
+        grade: "D",
+        warnings: ["Prompt quality engine is unavailable."],
+        suggestions: [],
+        secretFindings: [],
+        hasShortcutIntent: false,
+        hasIndependentAttempt: false
+      };
+    }
 
-    if (prompt.length >= 25) {
-      score += 10;
-      if (prompt.length >= 80) {
-        score += 6;
+    const analysis = engine.calculatePromptScore({
+      prompt,
+      strictMode,
+      profile: {
+        roleKey: clean(profile.roleKey || ""),
+        role: clean(profile.role || ""),
+        skill: clean(profile.skill || "")
       }
-    } else if (prompt.length >= 12) {
-      score += 4;
-      suggestions.push("Prompt is brief. Add more specifics before sending.");
-    } else {
-      warnings.push("Prompt is too short. Add context before asking AI.");
-    }
-
-    const contextEvidence = evaluateContextEvidence(prompt);
-    const hasStrongContext =
-      contextEvidence.hasErrorSignal &&
-      contextEvidence.hasExpectedActualPair &&
-      contextEvidence.hasArtifactSignal;
-
-    if (hasStrongContext) {
-      score += 28;
-    } else {
-      const evidenceCount =
-        Number(contextEvidence.hasErrorSignal) +
-        Number(contextEvidence.hasExpectedActualPair) +
-        Number(contextEvidence.hasArtifactSignal);
-
-      if (evidenceCount === 2) {
-        score += 12;
-      } else if (evidenceCount === 1) {
-        score += 5;
-      }
-
-      if (!contextEvidence.hasErrorSignal) {
-        suggestions.push("Add the concrete error/failure signal you see.");
-      }
-      if (!contextEvidence.hasExpectedActualPair) {
-        suggestions.push("Add both expected result and actual result.");
-      }
-      if (!contextEvidence.hasArtifactSignal) {
-        suggestions.push("Add artifacts: file path, line, snippet, log, or endpoint.");
-      }
-    }
-
-    const attemptQuality = evaluateAttemptQuality(prompt);
-    if (attemptQuality.hasNegativeAttemptSignal) {
-      score -= 16;
-      warnings.push("Prompt says no attempt was made. Try one step first, then ask AI.");
-    }
-
-    if (
-      attemptQuality.hasActionSignal &&
-      attemptQuality.hasResultSignal &&
-      attemptQuality.hasBlockerSignal &&
-      !attemptQuality.hasNegativeAttemptSignal
-    ) {
-      score += 26;
-    } else if (
-      attemptQuality.hasActionSignal &&
-      attemptQuality.hasResultSignal &&
-      !attemptQuality.hasNegativeAttemptSignal
-    ) {
-      score += 16;
-      suggestions.push("Good progress. Add your current blocker to improve coaching quality.");
-    } else if (attemptQuality.hasActionSignal && !attemptQuality.hasNegativeAttemptSignal) {
-      score += 8;
-      suggestions.push("Add result of your attempt and where you are blocked.");
-    } else if (!attemptQuality.hasNegativeAttemptSignal) {
-      suggestions.push("Add what you tried, what happened, and where you got stuck.");
-    }
-
-    const shortcutIntent = hasShortcutIntent(prompt);
-    if (shortcutIntent) {
-      warnings.push("Prompt asks for shortcuts. Ask for guidance first, not full copy-paste code.");
-      score -= 20;
-    } else {
-      score += 8;
-    }
-
-    if (hasStructuredSections(prompt)) {
-      score += 18;
-    } else {
-      suggestions.push("Use structured sections: Task/Context/Attempt (or Nhiem vu/Boi canh/Da thu).");
-    }
-
-    if (strictMode && shortcutIntent && !attemptQuality.hasIndependentAttempt) {
-      score -= 14;
-      warnings.push("Strict mode: include your attempt and blocker before asking for final code.");
-    }
-
-    score = Math.max(0, Math.min(100, score));
+    });
 
     return {
-      score,
-      grade: scoreGrade(score),
-      warnings,
-      suggestions,
-      secretFindings: [],
-      hasShortcutIntent: shortcutIntent,
-      hasIndependentAttempt: attemptQuality.hasIndependentAttempt
+      ...analysis,
+      secretFindings: []
     };
   }
 
@@ -932,13 +878,24 @@
 
     const riskPenalty = Math.min(24, secretScan.findings.length * 8);
     const score = Math.max(0, analysis.score - riskPenalty);
+    const nextRisk = Math.max(0, (analysis.risk || 0) - Math.min(riskPenalty, analysis.risk || 0));
+    const nextBreakdown = Array.isArray(analysis.breakdown)
+      ? analysis.breakdown.map((part) =>
+          part.label === "Risk Guardrails"
+            ? { ...part, score: nextRisk }
+            : part
+        )
+      : analysis.breakdown;
 
     return {
       ...analysis,
+      risk: nextRisk,
+      total: score,
       score,
       grade: scoreGrade(score),
       warnings,
       suggestions,
+      breakdown: nextBreakdown,
       secretFindings: secretScan.findings.map((finding) => ({
         name: finding.name,
         severity: finding.severity
@@ -1069,7 +1026,7 @@
     const { settings, profile } = await getState();
     const analysis = applySecretFindingsToAnalysis(
       prompt,
-      analyzePrompt(prompt, settings.strictMode)
+      analyzePrompt(prompt, settings.strictMode, profile)
     );
     const runtimeEvaluation = buildRuntimeEvaluation(prompt, analysis);
     const statsPromise = updatePromptStats(analysis);
@@ -1319,7 +1276,7 @@
 
     const analysis = applySecretFindingsToAnalysis(
       redactedPrompt,
-      analyzePrompt(redactedPrompt, settings.strictMode)
+      analyzePrompt(redactedPrompt, settings.strictMode, cachedProfile)
     );
     const runtimeEvaluation = buildRuntimeEvaluation(redactedPrompt, analysis);
 
@@ -1354,14 +1311,14 @@
       return;
     }
 
-    const settings = await getCurrentSettings();
+    const { settings, profile } = await getState();
     if (!settings.promptListenerEnabled || !settings.readPromptContentEnabled) {
       return;
     }
 
     const analysis = applySecretFindingsToAnalysis(
       prompt,
-      analyzePrompt(prompt, settings.strictMode)
+      analyzePrompt(prompt, settings.strictMode, profile)
     );
     const runtimeEvaluation = buildRuntimeEvaluation(prompt, analysis);
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -55,6 +55,7 @@
       "js": [
         "content/aiOverlay.js",
         "content/liveCoachBubble.js",
+        "shared/promptQualityEngine.js",
         "content/quickBuilder.js",
         "content/secretDetection.js",
         "content/monitor.js",

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -137,6 +137,7 @@
     </section>
   </main>
 
+  <script src="../shared/promptQualityEngine.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -280,9 +280,6 @@ const ROLE_TEMPLATE_RECOMMENDATIONS = {
 };
 const LEVEL_OPTIONS = new Set(["Student", "Junior", "Middle", "Senior"]);
 const REQUIRED_KEYS = ["task", "context", "attempt"];
-const REASONING_HINTS = [/tried/i, /attempt/i, /hypothesis/i, /debug/i, /test/i, /measure/i, /analy/i];
-const CONTEXT_HINTS = [/error/i, /stack/i, /file/i, /endpoint/i, /metric/i, /latency/i, /throughput/i, /trace/i];
-const SHORTCUT_PATTERNS = [/give me full code/i, /do it for me/i, /just answer/i, /no explanation/i, /copy paste/i];
 
 const roleSelect = document.getElementById("roleSelect");
 const customRoleInput = document.getElementById("customRoleInput");
@@ -324,6 +321,14 @@ function storageSet(payload) {
 
 function clean(value) {
   return (value || "").trim();
+}
+
+function getPromptQualityEngine() {
+  const engine = window.AIDevCoachPromptQualityEngine;
+  if (!engine || typeof engine.calculatePromptScore !== "function") {
+    throw new Error("Prompt quality engine is unavailable.");
+  }
+  return engine;
 }
 
 function normalizeLevel(value) {
@@ -605,19 +610,6 @@ function renderStats(stats) {
   habitStats.textContent = `AI requests: ${stats.aiRequests} | Manual attempts: ${stats.manualAttempts} | Dependency: ${dependency}% | Bad prompts: ${stats.badPrompts} | Shortcut prompts: ${stats.shortcutPrompts} | Large pastes: ${stats.largePastes} | AI copies: ${stats.aiCopies} | Fast copies: ${stats.fastAiCopies}`;
 }
 
-function gradeFromScore(score) {
-  if (score >= 90) {
-    return "A";
-  }
-  if (score >= 75) {
-    return "B";
-  }
-  if (score >= 60) {
-    return "C";
-  }
-  return "D";
-}
-
 function gradeClass(grade) {
   if (grade === "A") {
     return "grade--a";
@@ -634,166 +626,24 @@ function gradeClass(grade) {
   return "grade--na";
 }
 
-function countKeywordMatches(text, patterns) {
-  return patterns.filter((pattern) => pattern.test(text)).length;
-}
-
 function scorePrompt({ templateKey, profile, fields, prompt, roleProfile }) {
   const resolvedRoleProfile = roleProfile || getRoleProfile(profile);
-  const joined = `${fields.task}\n${fields.context}\n${fields.attempt}\n${fields.constraints}\n${fields.acceptance}`;
-
-  const breakdown = [];
-  const tips = [];
-  const warnings = [];
-
-  let completeness = 0;
-  if (fields.task.length >= 20) {
-    completeness += 12;
-  } else if (fields.task.length >= 8) {
-    completeness += 6;
-    tips.push("Make the task more specific with expected output and scope.");
-  } else {
-    warnings.push("Task is too short.");
-  }
-
-  if (fields.context.length >= 40) {
-    completeness += 12;
-  } else if (fields.context.length >= 15) {
-    completeness += 6;
-    tips.push("Add richer context (files, errors, expected vs actual behavior).");
-  } else {
-    warnings.push("Context is too thin.");
-  }
-
-  if (fields.attempt.length >= 30) {
-    completeness += 10;
-  } else if (fields.attempt.length >= 12) {
-    completeness += 5;
-    tips.push("Describe your attempts and blockers more clearly.");
-  } else {
-    warnings.push("What you tried needs more detail.");
-  }
-
-  if (profile.role) {
-    completeness += 3;
-  }
-  if (profile.skill) {
-    completeness += 3;
-  }
-
-  completeness = Math.min(40, completeness);
-  breakdown.push({ label: "Completeness", score: completeness, max: 40 });
-
-  let specificity = 0;
-  const contextSignalCount = countKeywordMatches(joined, CONTEXT_HINTS);
-  specificity += Math.min(10, contextSignalCount * 2);
-  const roleSignalCount = countKeywordMatches(joined, resolvedRoleProfile.roleSignals || []);
-  specificity += Math.min(4, roleSignalCount);
-
-  if (fields.constraints.length >= 16) {
-    specificity += 6;
-  }
-
-  if (fields.acceptance.length >= 16) {
-    specificity += 5;
-  }
-
-  if (prompt.length >= 450) {
-    specificity += 4;
-  }
-
-  specificity = Math.min(25, specificity);
-  if (specificity < 12) {
-    tips.push("Add concrete technical context (metrics, paths, traces, API details).");
-  }
-  if (roleSignalCount === 0) {
-    tips.push(`Add role-specific context for ${resolvedRoleProfile.label.toLowerCase()} scenarios.`);
-  }
-  breakdown.push({ label: "Specificity", score: specificity, max: 25 });
-
-  let reasoning = 0;
-  const reasoningSignalCount = countKeywordMatches(fields.attempt, REASONING_HINTS);
-  reasoning += Math.min(12, reasoningSignalCount * 3);
-
-  if (/why|trade-?off|because|assumption/i.test(joined)) {
-    reasoning += 4;
-  }
-
-  if (/test|verify|benchmark|validate/i.test(joined)) {
-    reasoning += 4;
-  }
-
-  reasoning = Math.min(20, reasoning);
-  if (reasoning < 10) {
-    tips.push("Include reasoning: assumptions, hypotheses, and validation plan.");
-  }
-  breakdown.push({ label: "Reasoning Evidence", score: reasoning, max: 20 });
-
-  let safety = 15;
-  const shortcutHit = SHORTCUT_PATTERNS.some((pattern) => pattern.test(joined));
-  if (shortcutHit) {
-    safety -= 8;
-    warnings.push("Shortcut language detected. Ask for guidance before final code.");
-  }
-
-  if (/step-?by-?step|explain|coach|review/i.test(prompt)) {
-    safety += 2;
-  }
-
-  if (/just.*answer|only.*code/i.test(joined)) {
-    safety -= 4;
-  }
-
-  if (
-    resolvedRoleProfile.key === "doctor" &&
-    /\bdiagnos(e|is)|prescrib|dosage|treatment plan|medical advice\b/i.test(joined)
-  ) {
-    safety -= 4;
-    warnings.push(
-      "Doctor mode safety: ask for educational reasoning and differential guidance, not direct diagnosis or prescriptions."
-    );
-  }
-
-  safety = Math.max(0, Math.min(15, safety));
-  breakdown.push({ label: "Learning Safety", score: safety, max: 15 });
-
-  let templateFit = 0;
-  const templateSignals = {
-    debugging: /error|stack|trace|bug|failing/i,
-    code_review: /review|regression|security|test/i,
-    system_design: /architecture|scal|throughput|availability|trade-?off/i,
-    refactoring: /refactor|maintain|readability|structure/i,
-    performance_optimization: /latency|cpu|memory|throughput|benchmark|optimi/i,
-    learning: /learn|explain|exercise|understand|concept/i
-  };
-
-  if (templateSignals[templateKey] && templateSignals[templateKey].test(joined)) {
-    templateFit = 5;
-  } else {
-    tips.push("Add terms that match the selected template objective.");
-  }
-  breakdown.push({ label: "Template Fit", score: templateFit, max: 5 });
-
-  const total = breakdown.reduce((sum, item) => sum + item.score, 0);
-  const score = Math.max(0, Math.min(100, total));
-  const grade = gradeFromScore(score);
-
-  let summary = "Strong prompt. Ready to use with AI.";
-  if (grade === "B") {
-    summary = "Good prompt. A bit more context can improve answer quality.";
-  } else if (grade === "C") {
-    summary = "Fair prompt. Improve context and reasoning before sending.";
-  } else if (grade === "D") {
-    summary = "Weak prompt. Add details and attempt notes first.";
-  }
+  const engine = getPromptQualityEngine();
+  const analysis = engine.calculatePromptScore({
+    prompt,
+    fields,
+    templateKey,
+    roleSignals: resolvedRoleProfile.roleSignals || [],
+    profile: {
+      roleKey: resolvedRoleProfile.key || profile.roleKey || "",
+      role: profile.role || "",
+      skill: profile.skill || ""
+    }
+  });
 
   return {
-    score,
-    grade,
-    summary,
-    warnings,
-    tips,
-    breakdown
+    ...analysis,
+    tips: analysis.suggestions
   };
 }
 

--- a/extension/shared/promptQualityEngine.js
+++ b/extension/shared/promptQualityEngine.js
@@ -1,0 +1,583 @@
+(() => {
+  const DIMENSION_MAX = {
+    clarity: 25,
+    context: 30,
+    specificity: 30,
+    risk: 15
+  };
+
+  const CONTEXT_ERROR_HINTS = [
+    /\berror\b/i,
+    /\b(?:type|reference|syntax|runtime|range)error\b/i,
+    /\bexception\b/i,
+    /\btraceback\b/i,
+    /\bstack\s*trace\b/i,
+    /\bfailed?\b/i,
+    /\bfailure\b/i,
+    /\bcrash(ed)?\b/i,
+    /\bbug\b/i,
+    /l[ôo]i/i,
+    /ngo[ạa]i\s*l[ệe]/i,
+    /kh[ôo]ng\s+ch[ạa]y/i,
+    /b[ịi]\s*l[ôo]i/i
+  ];
+
+  const CONTEXT_EXPECTED_HINTS = [
+    /\bexpected\b/i,
+    /\bshould\b/i,
+    /\bintend(ed)?\b/i,
+    /\btarget behavior\b/i,
+    /mong\s*[đd]?[ợo]i/i,
+    /k[ỳy]\s*v[ọo]ng/i,
+    /\bmu[ốo]n\b/i,
+    /[đd][aá]ng\s*l[ẽe]/i
+  ];
+
+  const CONTEXT_ACTUAL_HINTS = [
+    /\bactual\b/i,
+    /\bcurrently\b/i,
+    /\binstead\b/i,
+    /\bobserved\b/i,
+    /\breturns?\b/i,
+    /\bhappens?\b/i,
+    /th[ựu]c\s*t[ếe]/i,
+    /hi[ệe]n\s*t[ạa]i/i,
+    /nh[ưu]ng/i,
+    /\bv[ẫa]n\b/i
+  ];
+
+  const CONTEXT_ARTIFACT_HINTS = [
+    /```/,
+    /line\s*\d+/i,
+    /[a-z0-9_./-]+\.[a-z0-9]+(:\d{1,5})?/i,
+    /\bfile\b/i,
+    /\bpath\b/i,
+    /\bmodule\b/i,
+    /\bclass\b/i,
+    /\bfunction\b/i,
+    /\bmethod\b/i,
+    /\bendpoint\b/i,
+    /\bsql\b/i,
+    /\blog\b/i,
+    /\brepo\b/i,
+    /\bbranch\b/i,
+    /\bcommit\b/i,
+    /\bdiff\b/i,
+    /\bpayload\b/i,
+    /\brequest\b/i,
+    /\bresponse\b/i,
+    /t[ệe]p/i,
+    /d[òo]ng\s*\d+/i,
+    /h[àa]m/i,
+    /nh[áa]nh/i,
+    /[ảa]nh\s*(m[àa]n\s*h[ìi]nh)?/i
+  ];
+
+  const ATTEMPT_ACTION_HINTS = [
+    /\bi tried\b/i,
+    /\bi attempted\b/i,
+    /\bi tested\b/i,
+    /\bi changed\b/i,
+    /\bi debugged\b/i,
+    /\bi ran\b/i,
+    /\bi checked\b/i,
+    /\bi profiled\b/i,
+    /[đd][aã]\s*th[ửu]/i,
+    /\bt[ôo]i\s*th[ửu]\b/i,
+    /\bem\s*th[ửu]\b/i,
+    /[đd][aã]\s*ch[ạa]y/i,
+    /[đd][aã]\s*ki[ểe]m\s*tra/i,
+    /[đd][aã]\s*debug/i
+  ];
+
+  const ATTEMPT_RESULT_HINTS = [
+    /\bit still\b/i,
+    /\bstill fails?\b/i,
+    /\bi got\b/i,
+    /\bresult(ed)?\b/i,
+    /\boutputs?\b/i,
+    /\bthrows?\b/i,
+    /\bnow\b/i,
+    /k[ếe]t\s*qu[ảa]/i,
+    /b[ịi]\s*l[ôo]i/i,
+    /ra\s*l[ôo]i/i,
+    /kh[ôo]ng\s*[đd][ổo]i/i,
+    /\bv[ẫa]n\b/i
+  ];
+
+  const ATTEMPT_BLOCKER_HINTS = [
+    /\bstuck\b/i,
+    /\bblocked\b/i,
+    /\bnot sure\b/i,
+    /\bdon'?t understand\b/i,
+    /\bcannot\b/i,
+    /\bcan'?t\b/i,
+    /\bunsure\b/i,
+    /\bneed help\b/i,
+    /\bb[íi]\b/i,
+    /v[ưu][ớo]ng/i,
+    /kh[ôo]ng\s*bi[ếe]t/i,
+    /ch[ưu]a\s*hi[ểe]u/i,
+    /kh[óo]\s*kh[ăa]n/i
+  ];
+
+  const ATTEMPT_NEGATIVE_HINTS = [
+    /\bi (did not|didn'?t|have not|haven'?t) (try|attempt)\b/i,
+    /\bi didn'?t do anything\b/i,
+    /\bch[ưu]a\s*th[ửu]\b/i,
+    /kh[ôo]ng\s*th[ửu]/i,
+    /ch[ưu]a\s*l[aà]m\s*g[ìi]/i
+  ];
+
+  const SHORTCUT_HINTS = [
+    /give me full code/i,
+    /do it for me/i,
+    /just give me answer/i,
+    /no explanation/i,
+    /copy and paste/i,
+    /urgent.*fix/i,
+    /vi[ếe]t.*full\s*code/i,
+    /l[aà]m\s+h[ộo]\s*t[ôo]i/i,
+    /cho\s*t[ôo]i\s*[đd][aá]p\s*[aá]n\s*ngay/i,
+    /kh[ôo]ng\s*c[ầa]n\s*gi[ảa]i\s*th[íi]ch/i
+  ];
+
+  const TASK_SECTION_HINTS = [
+    /task\s*:/i,
+    /goal\s*:/i,
+    /nhi[ệe]m\s*v[ụu]\s*:/i,
+    /m[ụu]c\s*ti[êe]u\s*:/i,
+    /y[êe]u\s*c[ầa]u\s*:/i
+  ];
+
+  const CONTEXT_SECTION_HINTS = [
+    /context\s*:/i,
+    /background\s*:/i,
+    /b[ốo]i\s*c[ảa]nh\s*:/i,
+    /ng[ữu]\s*c[ảa]nh\s*:/i
+  ];
+
+  const ATTEMPT_SECTION_HINTS = [
+    /(what i (already )?tried|attempt)\s*:/i,
+    /[đd][aã]\s*th[ửu]\s*:/i,
+    /t[ôo]i\s*[đd][aã]\s*th[ửu]\s*:/i,
+    /em\s*[đd][aã]\s*th[ửu]\s*:/i
+  ];
+
+  const FRAMEWORK_HINTS = [
+    { label: "React", regex: /\breact\b/i },
+    { label: "Next.js", regex: /\bnext(?:\.js)?\b/i },
+    { label: "Vue", regex: /\bvue\b/i },
+    { label: "Angular", regex: /\bangular\b/i },
+    { label: "Node.js", regex: /\bnode(?:\.js)?\b/i },
+    { label: "Express", regex: /\bexpress\b/i },
+    { label: "Spring Boot", regex: /\bspring\s*boot\b/i },
+    { label: "Java", regex: /\bjava\b/i },
+    { label: "Python", regex: /\bpython\b/i },
+    { label: "Django", regex: /\bdjango\b/i },
+    { label: "Flask", regex: /\bflask\b/i },
+    { label: "SQL", regex: /\bsql\b/i },
+    { label: "PostgreSQL", regex: /\bpostgres(?:ql)?\b/i },
+    { label: "MySQL", regex: /\bmysql\b/i },
+    { label: "MongoDB", regex: /\bmongo(?:db)?\b/i },
+    { label: "Redis", regex: /\bredis\b/i },
+    { label: "Docker", regex: /\bdocker\b/i },
+    { label: "Kubernetes", regex: /\b(?:kubernetes|k8s)\b/i },
+    { label: "AWS", regex: /\baws\b/i },
+    { label: "GCP", regex: /\b(?:gcp|google cloud)\b/i },
+    { label: "Azure", regex: /\bazure\b/i },
+    { label: "Terraform", regex: /\bterraform\b/i },
+    { label: "Kafka", regex: /\bkafka\b/i },
+    { label: "Jest", regex: /\bjest\b/i },
+    { label: "Vitest", regex: /\bvitest\b/i },
+    { label: "Playwright", regex: /\bplaywright\b/i },
+    { label: "Cypress", regex: /\bcypress\b/i }
+  ];
+
+  const VAGUE_PHRASE_HINTS = [
+    { label: "fix this", regex: /\bfix this\b/i },
+    { label: "help me", regex: /\bhelp me\b/i },
+    { label: "why broken", regex: /\bwhy\s+(?:is\s+it\s+)?broken\b/i },
+    { label: "not working", regex: /\bnot working\b/i },
+    { label: "please solve", regex: /\b(?:please\s+)?solve (?:this|it)\b/i },
+    { label: "do it for me", regex: /\bdo it for me\b/i },
+    { label: "full code", regex: /\bfull code\b/i },
+    { label: "giup toi", regex: /gi[uú]p\s+t[ôo]i/i },
+    { label: "sua loi", regex: /s[ửu]a\s+l[ỗo]i/i },
+    { label: "khong hoat dong", regex: /kh[ôo]ng\s+ho[ạa]t\s+[đd][ộo]ng/i },
+    { label: "tai sao hong", regex: /t[ạa]i\s+sao\s+h[ỏo]ng/i }
+  ];
+
+  const TEMPLATE_SIGNALS = {
+    debugging: /error|stack|trace|bug|failing/i,
+    code_review: /review|regression|security|test/i,
+    system_design: /architecture|scal|throughput|availability|trade-?off/i,
+    refactoring: /refactor|maintain|readability|structure/i,
+    performance_optimization: /latency|cpu|memory|throughput|benchmark|optimi/i,
+    learning: /learn|explain|exercise|understand|concept/i
+  };
+
+  function clean(value) {
+    return (value || "").trim();
+  }
+
+  function uniquePush(list, value) {
+    if (!value || list.includes(value)) {
+      return;
+    }
+    list.push(value);
+  }
+
+  function countRegexMatches(text, patterns) {
+    return patterns.filter((pattern) => pattern.test(text)).length;
+  }
+
+  function findLabeledMatches(text, patterns) {
+    const matches = [];
+    patterns.forEach((pattern) => {
+      if (pattern.regex.test(text)) {
+        matches.push(pattern.label);
+      }
+    });
+    return matches;
+  }
+
+  function hasAnyHint(prompt, patterns) {
+    return patterns.some((pattern) => pattern.test(prompt));
+  }
+
+  function hasStructuredSections(prompt, fields) {
+    if (fields && clean(fields.task) && clean(fields.context) && clean(fields.attempt)) {
+      return true;
+    }
+
+    return (
+      hasAnyHint(prompt, TASK_SECTION_HINTS) &&
+      hasAnyHint(prompt, CONTEXT_SECTION_HINTS) &&
+      hasAnyHint(prompt, ATTEMPT_SECTION_HINTS)
+    );
+  }
+
+  function evaluateContextEvidence(prompt, fields) {
+    const contextSource = clean(fields && fields.context ? fields.context : prompt);
+    const fullSource = clean(prompt);
+    const hasErrorSignal = hasAnyHint(contextSource || fullSource, CONTEXT_ERROR_HINTS);
+    const hasExpectedSignal = hasAnyHint(contextSource || fullSource, CONTEXT_EXPECTED_HINTS);
+    const hasActualSignal = hasAnyHint(contextSource || fullSource, CONTEXT_ACTUAL_HINTS);
+    const hasExpectedActualPair = hasExpectedSignal && hasActualSignal;
+    const hasArtifactSignal = hasAnyHint(contextSource || fullSource, CONTEXT_ARTIFACT_HINTS);
+    const hasCodeBlock = /```|`[^`\n]+`/.test(fullSource);
+    const frameworkMatches = findLabeledMatches(fullSource, FRAMEWORK_HINTS);
+
+    return {
+      hasErrorSignal,
+      hasExpectedActualPair,
+      hasArtifactSignal,
+      hasCodeBlock,
+      frameworkMatches
+    };
+  }
+
+  function evaluateAttemptQuality(prompt, fields) {
+    const attemptSource = clean(fields && fields.attempt ? fields.attempt : prompt);
+    const source = attemptSource || clean(prompt);
+    const hasActionSignal = hasAnyHint(source, ATTEMPT_ACTION_HINTS);
+    const hasResultSignal = hasAnyHint(source, ATTEMPT_RESULT_HINTS);
+    const hasBlockerSignal = hasAnyHint(source, ATTEMPT_BLOCKER_HINTS);
+    const hasNegativeAttemptSignal = hasAnyHint(source, ATTEMPT_NEGATIVE_HINTS);
+    const hasIndependentAttempt = !hasNegativeAttemptSignal && hasActionSignal && hasResultSignal;
+
+    return {
+      hasActionSignal,
+      hasResultSignal,
+      hasBlockerSignal,
+      hasNegativeAttemptSignal,
+      hasIndependentAttempt
+    };
+  }
+
+  function hasShortcutIntent(prompt) {
+    return hasAnyHint(prompt, SHORTCUT_HINTS);
+  }
+
+  function gradeFromScore(score) {
+    if (score >= 90) {
+      return "A";
+    }
+    if (score >= 75) {
+      return "B";
+    }
+    if (score >= 60) {
+      return "C";
+    }
+    return "D";
+  }
+
+  function buildSummary(total, dimensionScores) {
+    if (total >= 90) {
+      return "Strong prompt. It has enough detail for a focused, teachable answer.";
+    }
+    if (total >= 75) {
+      return "Good prompt. A little more evidence can make the response sharper.";
+    }
+
+    const ranked = [
+      { key: "clarity", label: "clarity", score: dimensionScores.clarity / DIMENSION_MAX.clarity },
+      { key: "context", label: "context", score: dimensionScores.context / DIMENSION_MAX.context },
+      { key: "specificity", label: "specificity", score: dimensionScores.specificity / DIMENSION_MAX.specificity },
+      { key: "risk", label: "safe prompting habits", score: dimensionScores.risk / DIMENSION_MAX.risk }
+    ].sort((left, right) => left.score - right.score);
+
+    const weakest = ranked[0];
+    if (weakest.key === "context") {
+      return "Prompt needs stronger evidence. Add error details, expected vs actual behavior, and artifacts.";
+    }
+    if (weakest.key === "specificity") {
+      return "Prompt needs more specifics. Add what you tried, constraints, and success criteria.";
+    }
+    if (weakest.key === "risk") {
+      return "Prompt is relying too much on shortcuts. Ask for guidance, not just final output.";
+    }
+    return "Prompt is still vague. Tighten the ask and explain the exact outcome you want.";
+  }
+
+  function calculatePromptScore(input) {
+    const options = typeof input === "string" ? { prompt: input } : { ...(input || {}) };
+    const fields = options.fields || {};
+    const prompt = clean(options.prompt || "");
+    const taskText = clean(fields.task || prompt.split(/\n+/)[0] || "");
+    const constraintsText = clean(fields.constraints);
+    const acceptanceText = clean(fields.acceptance);
+    const roleSignals = Array.isArray(options.roleSignals) ? options.roleSignals : [];
+    const strictMode = !!options.strictMode;
+    const templateKey = options.templateKey || "";
+    const roleKey = options.profile && options.profile.roleKey ? options.profile.roleKey : "";
+
+    const warnings = [];
+    const suggestions = [];
+    const vagueMatches = findLabeledMatches(prompt, VAGUE_PHRASE_HINTS);
+    const contextEvidence = evaluateContextEvidence(prompt, fields);
+    const attemptQuality = evaluateAttemptQuality(prompt, fields);
+    const shortcutIntent = hasShortcutIntent(prompt);
+    const structuredSections = hasStructuredSections(prompt, fields);
+    const roleSignalCount = countRegexMatches(prompt, roleSignals);
+    const templateAligned = templateKey && TEMPLATE_SIGNALS[templateKey] ? TEMPLATE_SIGNALS[templateKey].test(prompt) : false;
+    const numericSpecificity = /\b\d+(?:ms|s|sec|seconds|%|x|kb|mb|gb|qps|rps|rpm)?\b/i.test(prompt);
+    const explicitAsk = /\b(debug|diagnos|explain|review|design|refactor|optimi|learn|teach|compare|analy[sz]e|help)\b/i.test(taskText || prompt);
+
+    let clarity = 0;
+    if (prompt.length >= 180) {
+      clarity += 8;
+    } else if (prompt.length >= 60) {
+      clarity += 6;
+    } else if (prompt.length >= 20) {
+      clarity += 3;
+      uniquePush(suggestions, "Add a bit more detail so AI has enough context to reason well.");
+    } else {
+      uniquePush(warnings, "Prompt is too short. Add a clearer task before sending.");
+    }
+
+    if (taskText.length >= 30) {
+      clarity += 8;
+    } else if (taskText.length >= 12) {
+      clarity += 5;
+      uniquePush(suggestions, "State the task more clearly, including the exact outcome you want.");
+    } else {
+      uniquePush(warnings, "Task is vague. Explain what you want AI to help you do.");
+    }
+
+    if (structuredSections) {
+      clarity += 5;
+    } else {
+      uniquePush(suggestions, "Use clear sections such as Task, Context, and What You Tried.");
+    }
+
+    if (explicitAsk) {
+      clarity += 2;
+    }
+
+    if (vagueMatches.length > 0) {
+      clarity -= Math.min(6, vagueMatches.length * 2);
+      uniquePush(
+        warnings,
+        `Vague phrasing detected (${vagueMatches.slice(0, 2).join(", ")}). Replace it with a concrete technical ask.`
+      );
+    } else {
+      clarity += 2;
+    }
+    clarity = Math.max(0, Math.min(DIMENSION_MAX.clarity, clarity));
+
+    let context = 0;
+    const contextEvidenceCount =
+      Number(contextEvidence.hasErrorSignal) +
+      Number(contextEvidence.hasExpectedActualPair) +
+      Number(contextEvidence.hasArtifactSignal);
+
+    if (contextEvidenceCount === 3) {
+      context += 18;
+    } else if (contextEvidenceCount === 2) {
+      context += 12;
+    } else if (contextEvidenceCount === 1) {
+      context += 6;
+    }
+
+    if (!contextEvidence.hasErrorSignal) {
+      uniquePush(suggestions, "Include the concrete error, failure, or symptom you are seeing.");
+    }
+    if (!contextEvidence.hasExpectedActualPair) {
+      uniquePush(suggestions, "Include both expected behavior and actual behavior.");
+    }
+    if (!contextEvidence.hasArtifactSignal) {
+      uniquePush(suggestions, "Add artifacts like file paths, logs, snippets, endpoints, or stack traces.");
+    }
+
+    if (contextEvidence.hasCodeBlock) {
+      context += 4;
+    } else if (/code|query|component|function|class|api/i.test(prompt)) {
+      uniquePush(suggestions, "Add a small code snippet or exact artifact when the issue is code-related.");
+    }
+
+    if (contextEvidence.frameworkMatches.length > 0) {
+      context += Math.min(6, 3 + contextEvidence.frameworkMatches.length);
+    } else {
+      uniquePush(suggestions, "Include framework or stack context (for example React, Spring Boot, SQL, Docker)." );
+    }
+
+    if (clean(fields.context).length >= 40) {
+      context += 2;
+    }
+
+    if (roleSignalCount > 0) {
+      context += Math.min(2, roleSignalCount);
+    }
+    context = Math.max(0, Math.min(DIMENSION_MAX.context, context));
+
+    let specificity = 0;
+    if (
+      attemptQuality.hasActionSignal &&
+      attemptQuality.hasResultSignal &&
+      attemptQuality.hasBlockerSignal &&
+      !attemptQuality.hasNegativeAttemptSignal
+    ) {
+      specificity += 14;
+    } else if (
+      attemptQuality.hasActionSignal &&
+      attemptQuality.hasResultSignal &&
+      !attemptQuality.hasNegativeAttemptSignal
+    ) {
+      specificity += 10;
+      uniquePush(suggestions, "Add the current blocker so AI can continue from where you got stuck.");
+    } else if (attemptQuality.hasActionSignal && !attemptQuality.hasNegativeAttemptSignal) {
+      specificity += 6;
+      uniquePush(suggestions, "Add what happened after your attempt and why it did not solve the problem.");
+    } else if (!attemptQuality.hasNegativeAttemptSignal) {
+      uniquePush(suggestions, "Describe what you already tried, what happened, and where you are blocked.");
+    }
+
+    if (constraintsText.length >= 16) {
+      specificity += 4;
+    }
+    if (acceptanceText.length >= 16) {
+      specificity += 4;
+    }
+    if (numericSpecificity) {
+      specificity += 4;
+    }
+    if (templateAligned) {
+      specificity += 4;
+    } else if (templateKey) {
+      uniquePush(suggestions, "Add details that match the chosen template objective.");
+    }
+    if (roleSignalCount > 0) {
+      specificity += Math.min(4, roleSignalCount);
+    }
+    specificity = Math.max(0, Math.min(DIMENSION_MAX.specificity, specificity));
+
+    let risk = DIMENSION_MAX.risk;
+    if (shortcutIntent) {
+      risk -= 7;
+      uniquePush(warnings, "Shortcut language detected. Ask for reasoning or next steps before asking for full code.");
+    }
+    if (attemptQuality.hasNegativeAttemptSignal) {
+      risk -= 5;
+      uniquePush(warnings, "Prompt says no attempt was made. Try one step first, then ask AI.");
+    }
+    if (/just.*answer|only.*code|no explanation/i.test(prompt)) {
+      risk -= 3;
+      uniquePush(warnings, "Prompt asks for an answer without explanation. Prefer coaching and verification guidance.");
+    }
+    if (strictMode && shortcutIntent && !attemptQuality.hasIndependentAttempt) {
+      risk -= 3;
+      uniquePush(warnings, "Strict mode: include your attempt and blocker before asking for final output.");
+    }
+    if (roleKey === "doctor" && /\bdiagnos(e|is)|prescrib|dosage|treatment plan|medical advice\b/i.test(prompt)) {
+      risk -= 4;
+      uniquePush(
+        warnings,
+        "Doctor mode safety: ask for educational reasoning and differential guidance, not direct diagnosis or prescriptions."
+      );
+    }
+    if (/step-?by-?step|explain|teach|coach|review|why/i.test(prompt)) {
+      risk += 1;
+    }
+    if (vagueMatches.length > 0) {
+      risk -= Math.min(4, vagueMatches.length);
+    }
+    risk = Math.max(0, Math.min(DIMENSION_MAX.risk, risk));
+
+    if (specificity < 12) {
+      uniquePush(suggestions, "Add constraints, acceptance criteria, or measurable targets to narrow the answer.");
+    }
+
+    const total = clarity + context + specificity + risk;
+    const grade = gradeFromScore(total);
+    const breakdown = [
+      { label: "Clarity", score: clarity, max: DIMENSION_MAX.clarity },
+      { label: "Context", score: context, max: DIMENSION_MAX.context },
+      { label: "Specificity", score: specificity, max: DIMENSION_MAX.specificity },
+      { label: "Risk Guardrails", score: risk, max: DIMENSION_MAX.risk }
+    ];
+
+    return {
+      clarity,
+      context,
+      specificity,
+      risk,
+      total,
+      score: total,
+      grade,
+      summary: buildSummary(total, { clarity, context, specificity, risk }),
+      warnings,
+      suggestions,
+      breakdown,
+      hasShortcutIntent: shortcutIntent,
+      hasIndependentAttempt: attemptQuality.hasIndependentAttempt,
+      signals: {
+        promptLength: prompt.length,
+        vagueMatches,
+        structuredSections,
+        contextEvidence,
+        attemptQuality,
+        frameworkMatches: contextEvidence.frameworkMatches,
+        roleSignalCount,
+        templateAligned
+      }
+    };
+  }
+
+  const api = {
+    DIMENSION_MAX,
+    gradeFromScore,
+    calculatePromptScore
+  };
+
+  if (typeof window !== "undefined") {
+    window.AIDevCoachPromptQualityEngine = api;
+  }
+  if (typeof globalThis !== "undefined") {
+    globalThis.AIDevCoachPromptQualityEngine = api;
+  }
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/scripts/test-prompt-quality-engine.mjs
+++ b/scripts/test-prompt-quality-engine.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const engine = require("../extension/shared/promptQualityEngine.js");
+
+const weakPrompt = engine.calculatePromptScore({
+  prompt: "help me fix this not working"
+});
+
+const strongPrompt = engine.calculatePromptScore({
+  prompt: [
+    "Task: Debug a failing React checkout form submit.",
+    "Context: In React 18 with Next.js, clicking submit throws `TypeError: cannot read properties of undefined` in src/components/CheckoutForm.tsx:87.",
+    "Expected: the form should create an order and redirect to /success.",
+    "Actual: the request never reaches POST /api/orders and the UI stays on the same page.",
+    "What I tried: I logged the payload, added a guard around formData.customer, and reran the flow.",
+    "Result: the payload is present, but `customer.id` is undefined when handleSubmit maps the DTO.",
+    "Blocker: I am not sure whether the bug is in the form state or the API mapper.",
+    "Constraints: Keep the fix small and avoid changing the API contract.",
+    "Acceptance criteria: identify root cause, suggest the smallest safe fix, and list one regression test."
+  ].join("\n"),
+  strictMode: true
+});
+
+const shortcutPrompt = engine.calculatePromptScore({
+  prompt: "Give me full code and no explanation. I didn't try anything yet.",
+  strictMode: true
+});
+
+assert.equal(typeof engine.calculatePromptScore, "function");
+assert.equal(typeof engine.gradeFromScore, "function");
+assert.ok(strongPrompt.score > weakPrompt.score, "strong prompt should outscore vague prompt");
+assert.ok(strongPrompt.context > weakPrompt.context, "strong prompt should have better context score");
+assert.ok(strongPrompt.specificity > weakPrompt.specificity, "strong prompt should have better specificity score");
+assert.ok(shortcutPrompt.hasShortcutIntent, "shortcut prompt should be flagged");
+assert.ok(shortcutPrompt.warnings.length > 0, "shortcut prompt should emit warnings");
+assert.ok(shortcutPrompt.risk < strongPrompt.risk, "shortcut prompt should have lower risk guardrail score");
+assert.ok(strongPrompt.signals.frameworkMatches.includes("React"), "framework detection should find React");
+
+console.log("Prompt quality engine checks passed.");


### PR DESCRIPTION
## Summary
- add a shared prompt quality engine used by both popup prompt builder and live monitoring
- upgrade scoring to four structured dimensions: clarity, context, specificity, and risk guardrails
- add prompt quality smoke checks to CI and update docs for the v2 scoring model

## What changed
- added `extension/shared/promptQualityEngine.js`
- switched popup scoring to the shared engine so generated prompts and live coaching use the same logic
- switched monitor scoring to the shared engine while preserving secret-detection penalties and live bubble updates
- added framework detection, vague-language detection, code-block/context evidence checks, and stronger attempt-quality analysis
- added `scripts/test-prompt-quality-engine.mjs` and wired it into CI

## Validation
- `node scripts/validate-extension.mjs`
- `node scripts/test-prompt-quality-engine.mjs`
- `find extension -type f -name '*.js' | sort | xargs -n1 node --check`
- `python3 -m mkdocs build --strict`
- `actionlint`
