### PR TITLE
feat(prompt): add prompt linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Validate prompt quality engine smoke checks
         run: node scripts/test-prompt-quality-engine.mjs
 
+      - name: Validate prompt linter smoke checks
+        run: node scripts/test-prompt-linter.mjs
+
       - name: Validate extension JavaScript syntax
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ AI Dev Coach is designed to protect the learning loop:
 - In-page Live Coach bubble with realtime prompt score and habit snapshot
 - 6 prompt templates: debugging, code review, system design, refactoring, performance optimization, learning
 - Prompt quality engine v2 with shared scoring across popup and live monitor (`clarity`, `context`, `specificity`, `risk guardrails`)
+- Prompt Linter with rule-based feedback for prompt length, technical context, failure signals, and sensitive data
 - Real-time prompt quality scoring on AI chat websites (draft + submit paths)
 - Sensitive data detection and local redaction for likely secrets before prompt submission
 - Warning overlays in top-right for shortcut prompts and risky copy-paste behavior
@@ -56,6 +57,7 @@ AI Dev Coach is designed to protect the learning loop:
 ```bash
 node scripts/validate-extension.mjs
 node scripts/test-prompt-quality-engine.mjs
+node scripts/test-prompt-linter.mjs
 find extension -type f -name '*.js' -print0 | xargs -0 -n1 node --check
 python3 -m mkdocs build --strict
 ```

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added prompt linter with rule-based checks for short prompts, missing technical context, missing failure signals, and sensitive data
+- added prompt-linter smoke checks in CI and popup lint results UI
 - added prompt quality engine v2 with shared scoring between popup prompt builder and live monitoring
 - added prompt-quality smoke checks in CI to guard scoring regressions
 - added local secret detection and redaction guardrail before prompt submission

--- a/docs/08-product/feature-spec.md
+++ b/docs/08-product/feature-spec.md
@@ -60,6 +60,23 @@ Analyzes each submitted prompt for:
 
 Outputs a shared quality score and targeted feedback across both popup prompt builder and live monitoring.
 
+## 3.1 Prompt Linter
+
+The extension also runs a lint-style ruleset to make feedback easier to scan before sending.
+
+Initial lint rules:
+
+- prompt too short
+- missing technical context
+- missing concrete error message for failure-oriented prompts
+- possible sensitive data
+
+Lint output:
+
+- shows pass and fail states in popup prompt builder
+- reuses the same rules in live monitoring
+- only blocks normal prompting when a severe rule is triggered, such as sensitive data detection
+
 Trigger behavior:
 
 - run in draft mode while typing with 500ms debounce (live bubble updates)

--- a/docs/08-product/prompt-builder-system.md
+++ b/docs/08-product/prompt-builder-system.md
@@ -112,6 +112,9 @@ Grade mapping:
 | - Specificity: 25/30                              |
 | - Risk Guardrails: 14/15                          |
 | Tips: Add framework version and one regression test|
+| Prompt Lint: 1 warning | 3 passed                 |
+| - ⚠ Missing technical context                     |
+| - ✓ No sensitive data detected                    |
 +---------------------------------------------------+
 | Habit Snapshot                                    |
 | AI requests | Manual attempts | Dependency | Paste |
@@ -160,6 +163,7 @@ Grade mapping:
 - Shortcut requests (copy-paste intent) reduce score and increase warnings.
 - Dictionaries support English and Vietnamese phrasing.
 - Popup scoring and live monitoring now use the same shared prompt-quality engine to keep results consistent.
+- Popup also shows prompt lint results with pass/fail output for short prompts, missing technical context, missing failure signals, and sensitive data.
 
 ## Current Implementation Files
 
@@ -170,3 +174,4 @@ Grade mapping:
 - `extension/content/quickBuilder.js`
 - `extension/content/monitor.js`
 - `extension/shared/promptQualityEngine.js`
+- `extension/shared/promptLinter.js`

--- a/extension/content/monitor.js
+++ b/extension/content/monitor.js
@@ -81,6 +81,8 @@
     grade: "N/A",
     warnings: [],
     suggestions: [],
+    lintResults: [],
+    lintSummary: null,
     secretFindings: [],
     hasShortcutIntent: false,
     hasIndependentAttempt: false,
@@ -322,6 +324,17 @@
       typeof window.AIDevCoachPromptQualityEngine.calculatePromptScore === "function"
     ) {
       return window.AIDevCoachPromptQualityEngine;
+    }
+
+    return null;
+  }
+
+  function getPromptLinter() {
+    if (
+      window.AIDevCoachPromptLinter &&
+      typeof window.AIDevCoachPromptLinter.lintPrompt === "function"
+    ) {
+      return window.AIDevCoachPromptLinter;
     }
 
     return null;
@@ -821,6 +834,8 @@
       grade: analysis.grade,
       warnings: analysis.warnings.slice(0, 4),
       suggestions: analysis.suggestions.slice(0, 4),
+      lintResults: Array.isArray(analysis.lintResults) ? analysis.lintResults.slice(0, 4) : [],
+      lintSummary: analysis.lintSummary || null,
       secretFindings: Array.isArray(analysis.secretFindings) ? analysis.secretFindings.slice(0, 4) : [],
       hasShortcutIntent: analysis.hasShortcutIntent,
       hasIndependentAttempt: analysis.hasIndependentAttempt,
@@ -855,7 +870,61 @@
 
     return {
       ...analysis,
+      lintResults: [],
+      lintSummary: null,
       secretFindings: []
+    };
+  }
+
+  function appendUniqueMessages(target, messages) {
+    messages.forEach((message) => {
+      if (!message || target.includes(message)) {
+        return;
+      }
+      target.push(message);
+    });
+  }
+
+  function applyLintResultsToAnalysis(prompt, analysis, profile = DEFAULT_PROFILE, templateKey = "") {
+    const linter = getPromptLinter();
+    if (!linter || !analysis || !prompt) {
+      return analysis;
+    }
+
+    const report = linter.lintPrompt({
+      prompt,
+      analysis,
+      templateKey,
+      profile: {
+        roleKey: clean(profile.roleKey || ""),
+        role: clean(profile.role || ""),
+        skill: clean(profile.skill || "")
+      }
+    });
+
+    const warnings = analysis.warnings.slice();
+    const suggestions = analysis.suggestions.slice();
+
+    appendUniqueMessages(
+      warnings,
+      report.failingResults
+        .filter((result) => result.severity === "error" || result.severity === "warning")
+        .map((result) => result.message)
+    );
+
+    appendUniqueMessages(
+      suggestions,
+      report.failingResults
+        .filter((result) => result.severity !== "error")
+        .map((result) => result.description)
+    );
+
+    return {
+      ...analysis,
+      warnings,
+      suggestions,
+      lintResults: report.results,
+      lintSummary: report.summary
     };
   }
 
@@ -1024,9 +1093,13 @@
     }
 
     const { settings, profile } = await getState();
-    const analysis = applySecretFindingsToAnalysis(
+    const analysis = applyLintResultsToAnalysis(
       prompt,
-      analyzePrompt(prompt, settings.strictMode, profile)
+      applySecretFindingsToAnalysis(
+        prompt,
+        analyzePrompt(prompt, settings.strictMode, profile)
+      ),
+      profile
     );
     const runtimeEvaluation = buildRuntimeEvaluation(prompt, analysis);
     const statsPromise = updatePromptStats(analysis);
@@ -1274,9 +1347,13 @@
     rememberDraftPrompt(redactedPrompt);
     rememberSecretBlock(prompt);
 
-    const analysis = applySecretFindingsToAnalysis(
+    const analysis = applyLintResultsToAnalysis(
       redactedPrompt,
-      analyzePrompt(redactedPrompt, settings.strictMode, cachedProfile)
+      applySecretFindingsToAnalysis(
+        redactedPrompt,
+        analyzePrompt(redactedPrompt, settings.strictMode, cachedProfile)
+      ),
+      cachedProfile
     );
     const runtimeEvaluation = buildRuntimeEvaluation(redactedPrompt, analysis);
 
@@ -1316,9 +1393,13 @@
       return;
     }
 
-    const analysis = applySecretFindingsToAnalysis(
+    const analysis = applyLintResultsToAnalysis(
       prompt,
-      analyzePrompt(prompt, settings.strictMode, profile)
+      applySecretFindingsToAnalysis(
+        prompt,
+        analyzePrompt(prompt, settings.strictMode, profile)
+      ),
+      profile
     );
     const runtimeEvaluation = buildRuntimeEvaluation(prompt, analysis);
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -58,6 +58,7 @@
         "shared/promptQualityEngine.js",
         "content/quickBuilder.js",
         "content/secretDetection.js",
+        "shared/promptLinter.js",
         "content/monitor.js",
         "content/interactionTracker.js"
       ],

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -394,6 +394,45 @@ textarea {
   color: var(--warning);
 }
 
+.lint-list {
+  list-style: none;
+  padding-left: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.lint-list li {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(176, 213, 236, 0.94);
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.lint-result--pass {
+  border-color: rgba(144, 219, 185, 0.9);
+  background: rgba(236, 252, 244, 0.92);
+  color: #116443;
+}
+
+.lint-result--warning {
+  border-color: rgba(248, 213, 166, 0.92);
+  background: rgba(255, 247, 234, 0.95);
+  color: #9f5703;
+}
+
+.lint-result--error {
+  border-color: rgba(243, 200, 196, 0.92);
+  background: rgba(254, 240, 239, 0.94);
+  color: #a62a22;
+}
+
+.lint-result--info {
+  border-color: rgba(195, 238, 250, 0.96);
+  background: rgba(241, 250, 255, 0.94);
+  color: #28567a;
+}
+
 .grade {
   border-radius: 999px;
   padding: 2px 8px;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -124,6 +124,14 @@
         <ul id="scoreTips" class="score-list score-list--tips"></ul>
       </section>
 
+      <section class="score-card" aria-label="Prompt lint results">
+        <div class="score-card__header">
+          <span>Prompt Lint</span>
+          <strong id="promptLintSummary">--</strong>
+        </div>
+        <ul id="lintResults" class="score-list lint-list"></ul>
+      </section>
+
       <p id="promptStatus" class="status"></p>
     </section>
 
@@ -138,6 +146,8 @@
   </main>
 
   <script src="../shared/promptQualityEngine.js"></script>
+  <script src="../content/secretDetection.js"></script>
+  <script src="../shared/promptLinter.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -310,6 +310,8 @@ const promptScoreGrade = document.getElementById("promptGrade");
 const promptScoreSummary = document.getElementById("promptScoreSummary");
 const scoreBreakdown = document.getElementById("scoreBreakdown");
 const scoreTips = document.getElementById("scoreTips");
+const promptLintSummary = document.getElementById("promptLintSummary");
+const lintResults = document.getElementById("lintResults");
 
 function storageGet(keys) {
   return new Promise((resolve) => chrome.storage.local.get(keys, resolve));
@@ -329,6 +331,14 @@ function getPromptQualityEngine() {
     throw new Error("Prompt quality engine is unavailable.");
   }
   return engine;
+}
+
+function getPromptLinter() {
+  const linter = window.AIDevCoachPromptLinter;
+  if (!linter || typeof linter.lintPrompt !== "function") {
+    throw new Error("Prompt linter is unavailable.");
+  }
+  return linter;
 }
 
 function normalizeLevel(value) {
@@ -677,6 +687,42 @@ function renderScore(analysis) {
   });
 }
 
+function lintClassForResult(result) {
+  if (result.passed) {
+    return result.severity === "info" ? "lint-result--info" : "lint-result--pass";
+  }
+  return result.severity === "error" ? "lint-result--error" : "lint-result--warning";
+}
+
+function renderLintResults(report) {
+  if (!report || !Array.isArray(report.results)) {
+    promptLintSummary.textContent = "--";
+    lintResults.innerHTML = "";
+    return;
+  }
+
+  const summaryParts = [];
+  if (report.summary.errors > 0) {
+    summaryParts.push(`${report.summary.errors} error`);
+  }
+  if (report.summary.warnings > 0) {
+    summaryParts.push(`${report.summary.warnings} warning`);
+  }
+  if (report.summary.passed > 0) {
+    summaryParts.push(`${report.summary.passed} passed`);
+  }
+  promptLintSummary.textContent = summaryParts.join(" | ") || "Clear";
+
+  lintResults.innerHTML = "";
+  report.results.forEach((result) => {
+    const item = document.createElement("li");
+    item.className = lintClassForResult(result);
+    const prefix = result.passed ? "✓" : result.severity === "error" ? "⛔" : "⚠";
+    item.textContent = `${prefix} ${result.message}`;
+    lintResults.appendChild(item);
+  });
+}
+
 function renderChecklist(fields) {
   const checks = REQUIRED_KEYS.map((key) => {
     const ok = fields[key] && fields[key].length > 0;
@@ -756,18 +802,35 @@ async function generatePrompt() {
   const prompt = [...buildRoleHeaderLines(roleProfile), "", basePrompt].join("\n");
 
   const analysis = scorePrompt({ templateKey, profile, fields, prompt, roleProfile });
+  const lintReport = getPromptLinter().lintPrompt({
+    prompt,
+    analysis,
+    fields,
+    templateKey,
+    profile: {
+      roleKey: resolvedRoleKey(profile),
+      role: profile.role || "",
+      skill: profile.skill || ""
+    }
+  });
 
   generatedPrompt.value = prompt;
   renderScore(analysis);
+  renderLintResults(lintReport);
 
   await storageSet({
     selectedTemplate: templateKey,
     profile,
     lastGeneratedPrompt: prompt,
-    lastPromptAnalysis: analysis
+    lastPromptAnalysis: analysis,
+    lastPromptLintReport: lintReport
   });
 
-  setStatus(promptStatus, `Prompt generated (${analysis.score}/100, grade ${analysis.grade}).`, true);
+  setStatus(
+    promptStatus,
+    `Prompt generated (${analysis.score}/100, grade ${analysis.grade}, ${lintReport.summary.failed} lint issue(s)).`,
+    true
+  );
 }
 
 async function copyGeneratedPrompt() {
@@ -793,6 +856,8 @@ function resetScoreCard() {
   promptScoreSummary.textContent = "Generate a prompt to calculate quality score.";
   scoreBreakdown.innerHTML = "";
   scoreTips.innerHTML = "";
+  promptLintSummary.textContent = "--";
+  lintResults.innerHTML = "";
 }
 
 async function loadState() {
@@ -802,7 +867,8 @@ async function loadState() {
     "stats",
     "selectedTemplate",
     "lastGeneratedPrompt",
-    "lastPromptAnalysis"
+    "lastPromptAnalysis",
+    "lastPromptLintReport"
   ]);
 
   const settings = { ...DEFAULT_SETTINGS, ...(data.settings || {}) };
@@ -834,6 +900,10 @@ async function loadState() {
     renderScore(data.lastPromptAnalysis);
   } else {
     resetScoreCard();
+  }
+
+  if (data.lastPromptLintReport) {
+    renderLintResults(data.lastPromptLintReport);
   }
 }
 

--- a/extension/shared/promptLinter.js
+++ b/extension/shared/promptLinter.js
@@ -1,0 +1,248 @@
+(() => {
+  const TECHNICAL_PROMPT_HINTS = [
+    /\bcode\b/i,
+    /\bapi\b/i,
+    /\bendpoint\b/i,
+    /\bfunction\b/i,
+    /\bclass\b/i,
+    /\bcomponent\b/i,
+    /\bquery\b/i,
+    /\bsql\b/i,
+    /\bbug\b/i,
+    /\berror\b/i,
+    /\btrace\b/i,
+    /\bstack\b/i,
+    /\bbuild\b/i,
+    /\bdeploy\b/i,
+    /\btest\b/i,
+    /\bdebug\b/i,
+    /m[ãa]\s*ngu[ồo]n/i,
+    /l[ỗo]i/i,
+    /truy\s*v[ấa]n/i,
+    /h[àa]m/i,
+    /api/i
+  ];
+
+  const FAILURE_PROMPT_HINTS = [
+    /\berror\b/i,
+    /\bexception\b/i,
+    /\btraceback\b/i,
+    /\bstack\s*trace\b/i,
+    /\bbug\b/i,
+    /\bfailed?\b/i,
+    /\bcrash(ed)?\b/i,
+    /\bbroken\b/i,
+    /\bnot working\b/i,
+    /\bissue\b/i,
+    /\bproblem\b/i,
+    /l[ỗo]i/i,
+    /kh[ôo]ng\s+ch[ạa]y/i,
+    /h[ỏo]ng/i
+  ];
+
+  const TECHNICAL_TEMPLATES = new Set([
+    'debugging',
+    'code_review',
+    'system_design',
+    'refactoring',
+    'performance_optimization'
+  ]);
+
+  const TECHNICAL_ROLE_KEYS = new Set(['software_engineer', 'solution_architecture']);
+
+  function clean(value) {
+    return (value || '').trim();
+  }
+
+  function getPromptQualityEngine() {
+    if (
+      typeof globalThis !== 'undefined' &&
+      globalThis.AIDevCoachPromptQualityEngine &&
+      typeof globalThis.AIDevCoachPromptQualityEngine.calculatePromptScore === 'function'
+    ) {
+      return globalThis.AIDevCoachPromptQualityEngine;
+    }
+
+    if (typeof require === 'function') {
+      try {
+        return require('./promptQualityEngine.js');
+      } catch (error) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  function getSecretGuard() {
+    if (
+      typeof globalThis !== 'undefined' &&
+      globalThis.AIDevCoachSecretGuard &&
+      typeof globalThis.AIDevCoachSecretGuard.inspectPromptForSecrets === 'function'
+    ) {
+      return globalThis.AIDevCoachSecretGuard;
+    }
+
+    if (typeof require === 'function') {
+      try {
+        return require('../content/secretDetection.js');
+      } catch (error) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  function hasAnyHint(text, patterns) {
+    return patterns.some((pattern) => pattern.test(text));
+  }
+
+  function buildContext(input) {
+    const options = typeof input === 'string' ? { prompt: input } : { ...(input || {}) };
+    const prompt = clean(options.prompt);
+    const qualityEngine = getPromptQualityEngine();
+    const analysis = options.analysis || (qualityEngine ? qualityEngine.calculatePromptScore(options) : null);
+    const secretGuard = getSecretGuard();
+    const secretInspection = options.secretInspection || (
+      secretGuard && typeof secretGuard.inspectPromptForSecrets === 'function'
+        ? secretGuard.inspectPromptForSecrets(prompt)
+        : { findings: [] }
+    );
+    const signals = analysis && analysis.signals ? analysis.signals : {};
+    const roleKey = clean(options.profile && options.profile.roleKey);
+    const isTechnicalPrompt =
+      TECHNICAL_TEMPLATES.has(options.templateKey) ||
+      TECHNICAL_ROLE_KEYS.has(roleKey) ||
+      hasAnyHint(prompt, TECHNICAL_PROMPT_HINTS);
+    const isFailurePrompt = options.templateKey === 'debugging' || hasAnyHint(prompt, FAILURE_PROMPT_HINTS);
+
+    return {
+      options,
+      prompt,
+      analysis,
+      signals,
+      secretInspection,
+      isTechnicalPrompt,
+      isFailurePrompt
+    };
+  }
+
+  function makeResult(rule, passed, message, severity = rule.severity) {
+    return {
+      id: rule.id,
+      title: rule.title,
+      description: rule.description,
+      severity,
+      passed,
+      message,
+      blocking: !passed && severity === 'error'
+    };
+  }
+
+  const PROMPT_LINT_RULES = [
+    {
+      id: 'prompt-too-short',
+      title: 'Prompt length',
+      description: 'Prompt should include enough detail to reason about the request.',
+      severity: 'warning',
+      check(context) {
+        const promptLength = context.signals.promptLength || context.prompt.length;
+        const structuredSections = !!context.signals.structuredSections;
+        if (promptLength >= 60 || structuredSections) {
+          return makeResult(this, true, 'Prompt length looks healthy.');
+        }
+        return makeResult(this, false, 'Prompt shorter than recommended length.');
+      }
+    },
+    {
+      id: 'missing-technical-context',
+      title: 'Technical context',
+      description: 'Technical prompts should include stack or artifact context.',
+      severity: 'warning',
+      check(context) {
+        if (!context.isTechnicalPrompt) {
+          return makeResult(this, true, 'Technical context rule not triggered for this prompt.', 'info');
+        }
+
+        const evidence = context.signals.contextEvidence || {};
+        const frameworkMatches = context.signals.frameworkMatches || [];
+        const hasTechnicalContext = !!evidence.hasArtifactSignal || frameworkMatches.length > 0;
+        if (hasTechnicalContext) {
+          return makeResult(this, true, 'Technical context is present.');
+        }
+        return makeResult(this, false, 'Missing technical context such as stack, file path, snippet, or endpoint.');
+      }
+    },
+    {
+      id: 'missing-error-message',
+      title: 'Failure signal',
+      description: 'Failure-oriented prompts should include the exact error or symptom.',
+      severity: 'warning',
+      check(context) {
+        if (!context.isFailurePrompt) {
+          return makeResult(this, true, 'No explicit failure flow detected.', 'info');
+        }
+
+        const evidence = context.signals.contextEvidence || {};
+        if (evidence.hasErrorSignal) {
+          return makeResult(this, true, 'Concrete error or failure signal detected.');
+        }
+        return makeResult(this, false, 'Missing concrete error message or runtime failure signal.');
+      }
+    },
+    {
+      id: 'possible-sensitive-data',
+      title: 'Sensitive data',
+      description: 'Prompts should not contain credentials, secrets, or private keys.',
+      severity: 'error',
+      check(context) {
+        const findings = (context.secretInspection && context.secretInspection.findings) || [];
+        if (findings.length === 0) {
+          return makeResult(this, true, 'No sensitive data detected.');
+        }
+
+        const labels = Array.from(new Set(findings.map((finding) => finding.name))).slice(0, 2).join(', ');
+        return makeResult(this, false, `Possible sensitive data detected: ${labels}.`);
+      }
+    }
+  ];
+
+  function lintPrompt(input) {
+    const context = buildContext(input);
+    const results = PROMPT_LINT_RULES.map((rule) => rule.check(context));
+    const failing = results.filter((result) => !result.passed);
+    const passing = results.filter((result) => result.passed);
+    const errors = failing.filter((result) => result.severity === 'error');
+    const warnings = failing.filter((result) => result.severity !== 'error');
+
+    return {
+      results,
+      summary: {
+        total: results.length,
+        passed: passing.length,
+        failed: failing.length,
+        errors: errors.length,
+        warnings: warnings.length
+      },
+      hasBlockingFailure: errors.length > 0,
+      failingResults: failing,
+      passingResults: passing
+    };
+  }
+
+  const api = {
+    PROMPT_LINT_RULES,
+    lintPrompt
+  };
+
+  if (typeof window !== 'undefined') {
+    window.AIDevCoachPromptLinter = api;
+  }
+  if (typeof globalThis !== 'undefined') {
+    globalThis.AIDevCoachPromptLinter = api;
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/scripts/test-prompt-linter.mjs
+++ b/scripts/test-prompt-linter.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const qualityEngine = require('../extension/shared/promptQualityEngine.js');
+const linter = require('../extension/shared/promptLinter.js');
+
+const weakPrompt = 'help me fix this not working';
+const weakReport = linter.lintPrompt({
+  prompt: weakPrompt,
+  analysis: qualityEngine.calculatePromptScore({ prompt: weakPrompt }),
+  templateKey: 'debugging',
+  profile: { roleKey: 'software_engineer' }
+});
+
+const strongPrompt = [
+  'Task: Debug failing React API form submit.',
+  'Context: In Next.js, clicking submit throws TypeError in src/app/api/orders/route.ts:42.',
+  'Expected: POST /api/orders should return 201.',
+  'Actual: it returns 500 and the UI stays on the same page.',
+  'What I tried: I logged the payload and checked zod parsing.',
+  'Result: customerId is undefined in the mapper.',
+  'Blocker: I am not sure whether the bug is in form state or API mapping.'
+].join('\n');
+const strongReport = linter.lintPrompt({
+  prompt: strongPrompt,
+  analysis: qualityEngine.calculatePromptScore({ prompt: strongPrompt }),
+  templateKey: 'debugging',
+  profile: { roleKey: 'software_engineer' }
+});
+
+const secretReport = linter.lintPrompt({
+  prompt: 'Task: review this key\nContext: api_key=sk-1234567890abcdefghijklmnop',
+  analysis: qualityEngine.calculatePromptScore({ prompt: 'Task: review this key\nContext: api_key=sk-1234567890abcdefghijklmnop' }),
+  secretInspection: {
+    findings: [{ name: 'API Key', severity: 'high' }]
+  },
+  profile: { roleKey: 'software_engineer' }
+});
+
+assert.equal(weakReport.results.length, 4);
+assert.ok(weakReport.failingResults.length >= 2, 'weak prompt should fail multiple lint rules');
+assert.ok(
+  weakReport.failingResults.some((result) => result.id === 'prompt-too-short'),
+  'weak prompt should fail prompt-too-short'
+);
+assert.ok(
+  weakReport.failingResults.some((result) => result.id === 'missing-technical-context'),
+  'weak prompt should fail missing technical context'
+);
+assert.ok(
+  strongReport.failingResults.every((result) => result.id !== 'prompt-too-short'),
+  'strong prompt should pass prompt length rule'
+);
+assert.ok(
+  strongReport.passingResults.some((result) => result.id === 'missing-error-message'),
+  'strong prompt should pass error signal rule'
+);
+assert.ok(secretReport.hasBlockingFailure, 'secret lint report should block on sensitive data');
+assert.ok(
+  secretReport.failingResults.some((result) => result.id === 'possible-sensitive-data'),
+  'secret lint report should fail sensitive data rule'
+);
+
+console.log('Prompt linter checks passed.');


### PR DESCRIPTION
## Summary
- add a shared prompt linter with rule-based pass/fail feedback
- surface lint results in popup prompt builder and reuse them in live monitoring
- add CI smoke coverage and docs for the lint rules

## Lint rules
- prompt too short
- missing technical context
- missing concrete error message for failure-oriented prompts
- possible sensitive data

## Validation
- `node scripts/validate-extension.mjs`
- `node scripts/test-prompt-quality-engine.mjs`
- `node scripts/test-prompt-linter.mjs`
- `find extension -type f -name '*.js' | sort | xargs -n1 node --check`
- `python3 -m mkdocs build --strict`
- `actionlint`
