### PR TITLE
chore(release): cut v1.2.17

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Dev Coach",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Coach developers to use AI with better reasoning, prompting, and coding habits.",
   "minimum_chrome_version": "114",
   "homepage_url": "https://github.com/phamhungptithcm/ai-dev-coach",


### PR DESCRIPTION
## Summary
- bump extension manifest version to `1.2.17`
- prepare GitHub release tag `v1.2.17`
- publish GitHub release and attempt Chrome Web Store publish after merge

## Validation
- release branch was generated from the protected release workflow
- manifest-only change for release version bump
