### PR TITLE
fix(release): configure git identity for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force
           TAG="${{ steps.version.outputs.tag }}"
           if git rev-parse "${TAG}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- configure git identity before creating annotated release tags in GitHub Actions
- fix the failing tag creation step in the extension release workflow

## Testing
- actionlint .github/workflows/release.yml
