### PR TITLE
fix(ci): harden release and workflow continuity

### DIFF
--- a/.github/workflows/apply-branch-protection.yml
+++ b/.github/workflows/apply-branch-protection.yml
@@ -13,15 +13,19 @@ jobs:
       GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
       REPO: ${{ github.repository }}
     steps:
-      - name: Validate admin token
+      - name: Detect admin token
+        id: token
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::Missing REPO_ADMIN_TOKEN secret. This workflow needs an admin-scoped token."
-            exit 1
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Missing REPO_ADMIN_TOKEN secret. Skipping branch protection apply because this workflow needs an admin-scoped token."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Apply protection to main
+        if: steps.token.outputs.available == 'true'
         run: |
           set -euo pipefail
           cat > main-protection.json <<'JSON'
@@ -40,7 +44,7 @@ jobs:
               "require_last_push_approval": false
             },
             "restrictions": null,
-            "required_linear_history": true,
+            "required_linear_history": false,
             "allow_force_pushes": false,
             "allow_deletions": false,
             "block_creations": false,
@@ -57,6 +61,7 @@ jobs:
           echo "Applied protection to main."
 
       - name: Apply protection to staging
+        if: steps.token.outputs.available == 'true'
         run: |
           set -euo pipefail
           cat > staging-protection.json <<'JSON'
@@ -64,7 +69,8 @@ jobs:
             "required_status_checks": {
               "strict": true,
               "contexts": [
-                "CI / validate"
+                "CI / validate",
+                "Staging Version Guard / guard"
               ]
             },
             "enforce_admins": false,
@@ -75,7 +81,7 @@ jobs:
               "require_last_push_approval": false
             },
             "restrictions": null,
-            "required_linear_history": true,
+            "required_linear_history": false,
             "allow_force_pushes": false,
             "allow_deletions": false,
             "block_creations": false,
@@ -90,3 +96,8 @@ jobs:
             "/repos/${REPO}/branches/staging/protection" \
             --input staging-protection.json >/dev/null
           echo "Applied protection to staging."
+
+      - name: Report skipped apply
+        if: steps.token.outputs.available != 'true'
+        run: |
+          echo "Branch protection workflow completed without changes because REPO_ADMIN_TOKEN is not configured."

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,7 +21,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 
 concurrency:
   group: prepare-extension-release-main
@@ -116,31 +115,54 @@ jobs:
 
       - name: Create or update release PR
         if: steps.changes.outputs.has_changes == 'true'
-        id: cpr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ github.token }}
-          commit-message: "chore(release): cut v${{ steps.version.outputs.version }}"
-          title: "chore(release): cut v${{ steps.version.outputs.version }}"
-          body: |
-            ## Summary
-            - bump extension manifest version to `${{ steps.version.outputs.version }}`
-            - prepare GitHub release tag `${{ steps.version.outputs.tag }}`
-            - keep release publish step on post-merge automation
-
-            ## Next
-            - review and approve this PR
-            - merge into `main`
-            - `Publish Extension Release` will tag, package, write release notes, and publish to Chrome Web Store
-          branch: release/v${{ steps.version.outputs.version }}
-          base: main
-          delete-branch: true
-
-      - name: Trigger CI for release PR branch
-        if: steps.cpr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
+          PUSH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
-          gh workflow run CI --ref "${{ steps.cpr.outputs.pull-request-branch }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          BRANCH="release/v${VERSION}"
+          TITLE="chore(release): cut ${TAG}"
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          git switch -C "${BRANCH}"
+          git add extension/manifest.json
+
+          if git diff --cached --quiet; then
+            echo "No manifest changes to commit for ${BRANCH}."
+          else
+            git commit -m "${TITLE}"
+          fi
+
+          git push --force-with-lease origin "HEAD:${BRANCH}"
+
+          cat > release-pr-body.md <<EOF
+          ## Summary
+          - bump extension manifest version to \`${VERSION}\`
+          - prepare GitHub release tag \`${TAG}\`
+          - keep release publish step on post-merge automation
+
+          ## Next
+          - review and approve this PR
+          - merge into \`main\`
+          - \`Publish Extension Release\` will tag, package, write release notes, and publish to Chrome Web Store
+          EOF
+
+          existing_pr=$(gh pr list --base main --head "${BRANCH}" --state open --json number --jq '.[0].number' || true)
+          if [ -n "${existing_pr}" ]; then
+            gh pr edit "${existing_pr}" --title "${TITLE}" --body-file release-pr-body.md
+            echo "Updated existing release PR #${existing_pr}."
+          else
+            gh pr create \
+              --base main \
+              --head "${BRANCH}" \
+              --title "${TITLE}" \
+              --body-file release-pr-body.md || {
+              echo "::warning::Release branch ${BRANCH} was pushed, but the workflow could not open the PR automatically."
+              echo "::warning::If GitHub Actions PR creation is disabled, create the PR manually from ${BRANCH} to main."
+            }
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
           fi
 
       - name: Upload and publish to Chrome Web Store
+        id: cws
         if: env.PUBLISH_TO_CWS == 'true'
         env:
           CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
@@ -133,6 +134,7 @@ jobs:
           ZIP_FILE: dist/ai-dev-coach-${{ steps.version.outputs.version }}.zip
         run: |
           set -euo pipefail
+          echo "status=publishing" >> "$GITHUB_OUTPUT"
 
           TOKEN_RESPONSE=$(curl --fail-with-body -sS https://oauth2.googleapis.com/token \
             -d "client_id=${CWS_CLIENT_ID}" \
@@ -161,16 +163,20 @@ jobs:
 
           if [ "${upload_status}" -ge 400 ]; then
             if printf '%s' "${upload_body}" | grep -qi "in review"; then
-              echo "::error::Chrome Web Store item is currently in review. GitHub release is ready, but store publish must wait until review completes."
+              echo "::notice::Chrome Web Store item is currently in review. GitHub release is ready, but store publish must wait until review completes."
+              echo "status=deferred_in_review" >> "$GITHUB_OUTPUT"
             else
               echo "::error::Chrome Web Store upload failed: ${upload_body}"
+              echo "status=failed_upload" >> "$GITHUB_OUTPUT"
+              exit 1
             fi
-            exit 1
+            exit 0
           fi
 
           final_upload_state=$(printf '%s' "${upload_body}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("uploadState",""))')
           if [ -z "${final_upload_state}" ]; then
             echo "::error::Upload response missing uploadState"
+            echo "status=failed_upload_state" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -187,6 +193,7 @@ jobs:
               if [ "${final_upload_state}" != "UPLOAD_IN_PROGRESS" ]; then
                 echo "::error::Unexpected uploadState while polling: ${final_upload_state}"
                 echo "${status_response}"
+                echo "status=failed_upload_state" >> "$GITHUB_OUTPUT"
                 exit 1
               fi
               sleep 10
@@ -195,6 +202,7 @@ jobs:
 
           if [ "${final_upload_state}" != "SUCCESS" ]; then
             echo "::error::Upload did not reach SUCCESS. Final uploadState=${final_upload_state}"
+            echo "status=failed_upload_state" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -206,8 +214,44 @@ jobs:
           publish_body=$(printf '%s\n' "${publish_raw}" | sed '$d')
 
           if [ "${publish_status}" -ge 400 ]; then
+            if printf '%s' "${publish_body}" | grep -qi "in review"; then
+              echo "::notice::Chrome Web Store accepted the release package, but publish is deferred while the item remains in review."
+              echo "status=deferred_in_review" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "::error::Chrome Web Store publish failed: ${publish_body}"
+            echo "status=failed_publish" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           echo "Publish response: ${publish_body}"
+          echo "status=published" >> "$GITHUB_OUTPUT"
+
+      - name: Write release summary
+        if: always()
+        run: |
+          {
+            echo "## Extension release summary"
+            echo ""
+            echo "- Version: \`${{ steps.version.outputs.version }}\`"
+            echo "- Tag: \`${{ steps.version.outputs.tag }}\`"
+            echo "- GitHub release: completed"
+            if [ "${PUBLISH_TO_CWS}" != "true" ]; then
+              echo "- Chrome Web Store: skipped by workflow input"
+            else
+              case "${{ steps.cws.outputs.status }}" in
+                published)
+                  echo "- Chrome Web Store: published successfully"
+                  ;;
+                deferred_in_review)
+                  echo "- Chrome Web Store: deferred because the item is currently in review"
+                  ;;
+                "")
+                  echo "- Chrome Web Store: not reached"
+                  ;;
+                *)
+                  echo "- Chrome Web Store: failed (\`${{ steps.cws.outputs.status }}\`)"
+                  ;;
+              esac
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/weekly-staging-to-main.yml
+++ b/.github/workflows/weekly-staging-to-main.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.diff.outputs.ahead != '0'
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           pr_number=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number' || true)
@@ -59,7 +59,7 @@ jobs:
       - name: Enable auto-merge (respect branch protections)
         if: steps.diff.outputs.ahead != '0'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
         run: |
           set -euo pipefail
           gh pr merge "${{ steps.pr.outputs.number }}" --auto --merge || \

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This docs pipeline does not change extension version, tags, or releases.
 
 - Release preparation now lives in `.github/workflows/prepare-release.yml`.
 - When extension code lands on `main`, it opens or updates a release PR like `chore(release): cut vX.Y.Z` instead of pushing directly to protected `main`.
+- The repository should allow GitHub Actions to create pull requests. If that setting is ever disabled, the workflow can use `REPO_ADMIN_TOKEN` so release preparation still runs without manual rescue.
 - After that release PR is approved and merged, `.github/workflows/release.yml` publishes the release:
   - reads the manifest version from `main`
   - creates the release tag `vX.Y.Z` if missing
@@ -96,6 +97,7 @@ This docs pipeline does not change extension version, tags, or releases.
   - packages the extension zip
   - creates or updates the GitHub Release
   - uploads and publishes the package to Chrome Web Store
+- If Chrome Web Store reports that the item is already in review, the workflow keeps the GitHub release successful and marks the store publish as deferred instead of failing the whole run.
 - Version bump is release-only on `main`. PRs into `staging` are guarded from release-version edits.
 
 ### Chrome Web Store Secrets
@@ -111,7 +113,7 @@ Configure these repository secrets before a `main` release run:
 Optional:
 
 - `CWS_PUBLISH_TARGET` (`default` or `trustedTesters`)
-- `REPO_ADMIN_TOKEN` (admin token for branch-protection automation and weekly sync admin merge fallback)
+- `REPO_ADMIN_TOKEN` (recommended for release PR creation, branch-protection automation, and weekly sync admin merge fallback)
 
 The release workflow exchanges the refresh token for an access token using OAuth, then calls the Chrome Web Store API upload and publish endpoints.
 

--- a/docs/03-deployment/ci-cd.md
+++ b/docs/03-deployment/ci-cd.md
@@ -15,7 +15,7 @@ This workflow is docs-only and never bumps extension version.
 
 - `prepare-release.yml`
 Runs on `main` when extension code changes land. It calculates the next version and opens or updates a release PR against protected `main` instead of pushing directly.
-It also dispatches CI for the release PR branch so required checks are available before merge.
+It pushes the release branch directly. The repository should allow GitHub Actions to create pull requests, and `REPO_ADMIN_TOKEN` remains a fallback if that setting is disabled later.
 
 - `release.yml`
 Runs on `main` when a release PR merges and `extension/manifest.json` changes, or by manual dispatch, to:
@@ -25,6 +25,8 @@ Runs on `main` when a release PR merges and `extension/manifest.json` changes, o
 4. package extension zip
 5. create or update the GitHub release
 6. upload + publish to Chrome Web Store API
+
+If the Chrome Web Store item is already under review, the workflow keeps the GitHub release successful and records the store publish as deferred instead of failing the whole release.
 
 - `weekly-staging-to-main.yml`
 Runs weekly (and on manual dispatch) to create/reuse a sync PR from `staging` to `main` when `staging` is ahead.
@@ -63,4 +65,4 @@ Manual workflow to apply branch protection policies for `main` and `staging` usi
 - `CWS_PUBLISHER_ID`
 - `CWS_EXTENSION_ID`
 - optional `CWS_PUBLISH_TARGET`
-- optional `REPO_ADMIN_TOKEN` (for branch-protection apply + weekly admin merge fallback)
+- optional `REPO_ADMIN_TOKEN` (recommended for release PR creation, branch-protection apply, and weekly admin merge fallback)

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -20,6 +20,10 @@
 - enforced release-only version policy by adding `staging-version-guard.yml` for PRs into `staging`
 - added weekly `staging` to `main` sync automation workflow with auto-merge request and admin fallback
 - added `apply-branch-protection.yml` to manage branch protection policy as code
+- fixed release tagging in GitHub Actions by configuring bot git identity before annotated tags are created
+- hardened release preparation and weekly sync to use `REPO_ADMIN_TOKEN` when repository policy blocks PR creation from the default Actions token
+- changed Chrome Web Store "item in review" handling so GitHub release workflows finish successfully and report store publish as deferred
+- aligned branch protection automation with merge-commit release flow and required `Staging Version Guard / guard` on `staging`
 
 ## v1.2.15
 


### PR DESCRIPTION
## Summary
- replace brittle automated release PR creation with a branch-and-PR flow that works with repo PR permissions
- make Chrome Web Store "in review" a deferred success instead of a failed release run
- align branch protection automation with actual merge strategy and required staging guard
- harden weekly sync and admin workflows so they degrade cleanly

## Validation
- actionlint -color
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- python3 -m mkdocs build --strict
