### PR TITLE
chore(ci): update GitHub Actions runtime dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '20'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -43,7 +43,7 @@ jobs:
         run: python3 -m mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
 

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -24,6 +24,7 @@
 - hardened release preparation and weekly sync to use `REPO_ADMIN_TOKEN` when repository policy blocks PR creation from the default Actions token
 - changed Chrome Web Store "item in review" handling so GitHub release workflows finish successfully and report store publish as deferred
 - aligned branch protection automation with merge-commit release flow and required `Staging Version Guard / guard` on `staging`
+- updated GitHub Actions dependencies to `actions/setup-python@v6` and `actions/upload-pages-artifact@v4` to stay ahead of the Node 20 deprecation path
 
 ## v1.2.15
 


### PR DESCRIPTION
## Summary
- upgrade setup-python to v6 in CI and docs deploy workflows
- upgrade upload-pages-artifact to v4
- document the runtime dependency refresh in the changelog

## Validation
- actionlint -color
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- python3 -m mkdocs build --strict
