### PR TITLE
chore(ci): opt workflows into node 24 runtime

### DIFF
--- a/.github/workflows/apply-branch-protection.yml
+++ b/.github/workflows/apply-branch-protection.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   protect:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - main
       - staging
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,6 +15,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: "pages"
   cancel-in-progress: true

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -22,6 +22,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: prepare-extension-release-main
   cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: publish-extension-release-main
   cancel-in-progress: false

--- a/.github/workflows/staging-version-guard.yml
+++ b/.github/workflows/staging-version-guard.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-staging-to-main.yml
+++ b/.github/workflows/weekly-staging-to-main.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -25,6 +25,7 @@
 - changed Chrome Web Store "item in review" handling so GitHub release workflows finish successfully and report store publish as deferred
 - aligned branch protection automation with merge-commit release flow and required `Staging Version Guard / guard` on `staging`
 - updated GitHub Actions dependencies to `actions/setup-python@v6` and `actions/upload-pages-artifact@v4` to stay ahead of the Node 20 deprecation path
+- enabled GitHub's `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` opt-in across workflows so future Node 24 runner changes are exercised now
 
 ## v1.2.15
 


### PR DESCRIPTION
## Summary
- opt all workflows into GitHub's Node 24 JavaScript action runtime now
- reduce risk from the June 2026 Node 20 deprecation cutover
- record the runtime opt-in in the changelog

## Validation
- actionlint -color
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- python3 -m mkdocs build --strict
