### PR TITLE
fix(release): accept CWS upload succeeded state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
                 "${STATUS_URL}")
               final_upload_state=$(printf '%s' "${status_response}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("uploadState",""))')
               echo "Upload polling attempt ${attempt}: ${final_upload_state}"
-              if [ "${final_upload_state}" = "SUCCESS" ]; then
+              if [ "${final_upload_state}" = "SUCCESS" ] || [ "${final_upload_state}" = "SUCCEEDED" ]; then
                 break
               fi
               if [ "${final_upload_state}" != "UPLOAD_IN_PROGRESS" ]; then
@@ -203,7 +203,7 @@ jobs:
             done
           fi
 
-          if [ "${final_upload_state}" != "SUCCESS" ]; then
+          if [ "${final_upload_state}" != "SUCCESS" ] && [ "${final_upload_state}" != "SUCCEEDED" ]; then
             echo "::error::Upload did not reach SUCCESS. Final uploadState=${final_upload_state}"
             echo "status=failed_upload_state" >> "$GITHUB_OUTPUT"
             exit 1

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -26,6 +26,7 @@
 - aligned branch protection automation with merge-commit release flow and required `Staging Version Guard / guard` on `staging`
 - updated GitHub Actions dependencies to `actions/setup-python@v6` and `actions/upload-pages-artifact@v4` to stay ahead of the Node 20 deprecation path
 - enabled GitHub's `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` opt-in across workflows so future Node 24 runner changes are exercised now
+- fixed Chrome Web Store upload polling to accept both `SUCCESS` and `SUCCEEDED` upload-state responses from the API
 
 ## v1.2.15
 


### PR DESCRIPTION
## Summary
- accept both  and  from Chrome Web Store upload polling
- keep release publish flow compatible with the current API response shape
- document the compatibility fix in the changelog

## Validation
- actionlint -color
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- python3 -m mkdocs build --strict
