### PR TITLE
feat: add local prompt session tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Validate prompt linter smoke checks
         run: node scripts/test-prompt-linter.mjs
 
+      - name: Validate learning analytics smoke checks
+        run: node scripts/test-learning-analytics.mjs
+
       - name: Validate extension JavaScript syntax
         run: |
           set -euo pipefail

--- a/docs/05-operations/monitoring.md
+++ b/docs/05-operations/monitoring.md
@@ -12,6 +12,23 @@ The MVP focuses on local behavioral indicators rather than server analytics.
 - `badPrompts`
 - `shortcutPrompts`
 
+## Local Prompt Event Tracking
+
+The V2 analytics foundation now stores prompt-session metadata locally under the `learningAnalytics` storage key.
+
+It tracks:
+
+- prompt source
+- AI platform
+- timestamp
+- prompt length
+- prompt score / grade
+- dependency percentage
+- warning count
+- lint failed count
+
+The event log does not store full prompt bodies. This keeps analytics useful for learning trends while preserving a conservative privacy boundary.
+
 ## Prompt Monitoring Modes
 
 - `draft` analysis: runs on input debounce (500ms) for realtime score preview
@@ -24,6 +41,8 @@ Draft analysis updates the live bubble but does not increment send-based counter
 - warning precision (low false positives)
 - prompt quality score trend
 - dependency score trend over time
+- average prompt length trend
+- platform/source usage mix
 
 ## Operational Risks
 

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- added local learning analytics event tracking for prompt submissions with popup snapshot summary
+- added future backend sync payload contract for prompt-session analytics rollout
+- added learning-analytics smoke checks in CI
 - added prompt linter with rule-based checks for short prompts, missing technical context, missing failure signals, and sensitive data
 - added prompt-linter smoke checks in CI and popup lint results UI
 - added prompt quality engine v2 with shared scoring between popup prompt builder and live monitoring

--- a/docs/08-product/feature-spec.md
+++ b/docs/08-product/feature-spec.md
@@ -100,6 +100,30 @@ Live bubble behavior:
 - bubble stays visible on supported AI pages and auto-remounts if site UI rerenders
 - bubble updates from both draft typing analysis and send-time analysis
 
+## 4.1 Learning Analytics (V2 Foundation)
+
+The first V2 analytics slice tracks prompt-session metadata locally.
+
+Tracked prompt-event fields currently include:
+
+- prompt source (`composer_submit`, `quick_builder`, send-only variants)
+- platform
+- timestamp
+- prompt length
+- prompt score and grade
+- dependency percentage at send time
+- independent-attempt flag
+- shortcut-intent flag
+- warning count
+- lint failed count
+- role and level metadata
+
+Privacy defaults:
+
+- analytics history is stored locally in `chrome.storage.local`
+- prompt text is not stored in the analytics event log
+- future backend sync is documented but not enabled yet
+
 ## 5. Sensitive Data Guardrail
 
 Before a prompt is sent, the extension can scan for likely secrets such as:

--- a/docs/08-product/learning-analytics.md
+++ b/docs/08-product/learning-analytics.md
@@ -1,0 +1,118 @@
+# Learning Analytics
+
+AI Dev Coach now includes the first V2 analytics foundation for prompt-session tracking.
+
+This release is intentionally privacy-first:
+
+- prompt events are stored locally in `chrome.storage.local`
+- prompt text is not stored in analytics history
+- only prompt metadata is kept for summaries and future trend views
+
+## What is tracked
+
+Each tracked event represents a submitted AI prompt.
+
+Current event fields:
+
+- `type`: `prompt_submitted`
+- `source`: for example `composer_submit`, `composer_send_only`, `quick_builder`, `quick_builder_send_only`
+- `platform`: ChatGPT, Claude, Gemini, Grok, DeepSeek, or `Unknown`
+- `timestamp`
+- `promptLength`
+- `score`
+- `grade`
+- `dependency`
+- `hasIndependentAttempt`
+- `hasShortcutIntent`
+- `warningCount`
+- `lintFailedCount`
+- `roleKey`
+- `skillLevel`
+
+## Local summary
+
+The popup now reads the local analytics store and shows a compact snapshot:
+
+- tracked prompts
+- average prompt score
+- average prompt length
+- last platform used
+- top source / top platform
+
+This is the first step toward daily summaries and trend views in later V2 stories.
+
+## Storage model
+
+The local analytics state is stored under the `learningAnalytics` key.
+
+```json
+{
+  "version": 1,
+  "promptEvents": [],
+  "summary": {
+    "totalPrompts": 0,
+    "scoredPrompts": 0,
+    "averageScore": null,
+    "averagePromptLength": null,
+    "lastPromptAt": 0,
+    "lastPlatform": "",
+    "platformCounts": {},
+    "sourceCounts": {},
+    "dayCounts": {}
+  },
+  "updatedAt": 0
+}
+```
+
+The extension keeps only the latest bounded event history locally to avoid unbounded storage growth.
+
+## Future sync contract
+
+Backend sync is not enabled yet, but the shared analytics module already exposes a payload contract for future rollout.
+
+Example payload:
+
+```json
+{
+  "schemaVersion": 1,
+  "exportedAt": 1760000000000,
+  "cursor": null,
+  "promptEvents": [
+    {
+      "clientEventId": "prompt_1760000000000_ab12cd",
+      "type": "prompt_submitted",
+      "source": "composer_submit",
+      "platform": "ChatGPT",
+      "timestamp": 1760000000000,
+      "dayKey": "2026-03-13",
+      "promptLength": 312,
+      "score": 82,
+      "grade": "B",
+      "dependency": 63,
+      "hasIndependentAttempt": true,
+      "hasShortcutIntent": false,
+      "warningCount": 1,
+      "lintFailedCount": 0,
+      "roleKey": "software_engineer",
+      "skillLevel": "Senior"
+    }
+  ]
+}
+```
+
+Planned V2 rollout:
+
+1. local prompt-session tracking
+2. daily session summaries
+3. trend charts
+4. optional backend sync
+
+## Privacy boundary
+
+Analytics does not store:
+
+- full prompt body
+- copied AI output body
+- secrets or redacted values
+
+This keeps the analytics foundation useful for learning insights without introducing unnecessary content retention.

--- a/extension/content/monitor.js
+++ b/extension/content/monitor.js
@@ -61,6 +61,7 @@
   };
 
   const DEFAULT_PROFILE = {
+    roleKey: "",
     role: "",
     skill: "",
     habitGoals: ""
@@ -335,6 +336,17 @@
       typeof window.AIDevCoachPromptLinter.lintPrompt === "function"
     ) {
       return window.AIDevCoachPromptLinter;
+    }
+
+    return null;
+  }
+
+  function getLearningAnalytics() {
+    if (
+      window.AIDevCoachLearningAnalytics &&
+      typeof window.AIDevCoachLearningAnalytics.trackPromptEvent === "function"
+    ) {
+      return window.AIDevCoachLearningAnalytics;
     }
 
     return null;
@@ -1004,17 +1016,64 @@
     await storageSet({ lastRuntimePromptEvaluation: runtimeEvaluation });
   }
 
-  async function handleSendOnly() {
+  function countFailedLintChecks(analysis) {
+    if (!analysis || !analysis.lintSummary) {
+      return 0;
+    }
+
+    return Number.isFinite(analysis.lintSummary.failed)
+      ? Math.max(0, Math.round(analysis.lintSummary.failed))
+      : 0;
+  }
+
+  async function trackPromptAnalyticsEvent(prompt, analysis, dependency, profile, options = {}) {
+    const learningAnalytics = getLearningAnalytics();
+    if (!learningAnalytics) {
+      return null;
+    }
+
+    const platform = detectPlatform();
+
+    try {
+      const nextState = await learningAnalytics.trackPromptEvent(chrome.storage.local, {
+        source: clean(options.source) || "composer_submit",
+        platform: clean(options.platform) || clean(platform?.name) || "Unknown",
+        timestamp: Date.now(),
+        promptLength: typeof prompt === "string" ? prompt.length : null,
+        score: analysis && Number.isFinite(analysis.score) ? analysis.score : null,
+        grade: clean(analysis?.grade || ""),
+        dependency,
+        hasIndependentAttempt: !!analysis?.hasIndependentAttempt,
+        hasShortcutIntent: !!analysis?.hasShortcutIntent,
+        warningCount: Array.isArray(analysis?.warnings) ? analysis.warnings.length : 0,
+        lintFailedCount: countFailedLintChecks(analysis),
+        roleKey: clean(profile?.roleKey || ""),
+        skillLevel: clean(profile?.skill || "")
+      });
+
+      return nextState && nextState.summary ? nextState.summary : null;
+    } catch (error) {
+      console.error("AI Dev Coach analytics tracking error", error);
+      return null;
+    }
+  }
+
+  async function handleSendOnly(options = {}) {
     if (shouldSkipSendPulse()) {
       return;
     }
 
     const { stats, dependency } = await updateSendOnlyStats();
+    const analyticsSummary = await trackPromptAnalyticsEvent("", null, dependency, cachedProfile, {
+      source: clean(options.source) || "composer_send_only"
+    });
+
     emitPromptAnalyzed({
       at: Date.now(),
       sendOnly: true,
       stats,
-      dependency
+      dependency,
+      analyticsSummary
     });
   }
 
@@ -1087,7 +1146,7 @@
     });
   }
 
-  async function handlePrompt(prompt) {
+  async function handlePrompt(prompt, options = {}) {
     if (!prompt || !prompt.trim()) {
       return;
     }
@@ -1108,12 +1167,16 @@
     if (!settings.enableCoach || !settings.promptListenerEnabled || !settings.readPromptContentEnabled) {
       const { stats, dependency } = await statsPromise;
       await runtimePromise;
+      const analyticsSummary = await trackPromptAnalyticsEvent(prompt, analysis, dependency, profile, {
+        source: clean(options.source) || "composer_submit"
+      });
       emitPromptAnalyzed({
         at: runtimeEvaluation.at,
         promptPreview: runtimeEvaluation.promptPreview,
         analysis: runtimeEvaluation,
         stats,
-        dependency
+        dependency,
+        analyticsSummary
       });
       return;
     }
@@ -1138,13 +1201,17 @@
 
     const { stats, dependency } = await statsPromise;
     await runtimePromise;
+    const analyticsSummary = await trackPromptAnalyticsEvent(prompt, analysis, dependency, profile, {
+      source: clean(options.source) || "composer_submit"
+    });
 
     emitPromptAnalyzed({
       at: runtimeEvaluation.at,
       promptPreview: runtimeEvaluation.promptPreview,
       analysis: runtimeEvaluation,
       stats,
-      dependency
+      dependency,
+      analyticsSummary
     });
 
     if (dependency >= settings.dependencyWarningThreshold) {
@@ -1663,7 +1730,7 @@
         }
 
         if (!settings.readPromptContentEnabled) {
-          await handleSendOnly();
+          await handleSendOnly({ source: "quick_builder_send_only" });
           return;
         }
 
@@ -1675,7 +1742,7 @@
           return;
         }
 
-        await handlePrompt(prompt);
+        await handlePrompt(prompt, { source: "quick_builder" });
       };
 
       analyzeFromBuilder().catch((error) => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -56,6 +56,7 @@
         "content/aiOverlay.js",
         "content/liveCoachBubble.js",
         "shared/promptQualityEngine.js",
+        "shared/learningAnalytics.js",
         "content/quickBuilder.js",
         "content/secretDetection.js",
         "shared/promptLinter.js",

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -124,6 +124,10 @@ body {
   gap: 10px;
 }
 
+.profile-card__head .profile-badge {
+  margin: 0;
+}
+
 h2 {
   margin: 0;
   font-size: 15px;
@@ -359,6 +363,34 @@ textarea {
   font-size: 12px;
   line-height: 1.45;
   color: #284d66;
+}
+
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.analytics-pill {
+  border: 1px solid rgba(176, 213, 236, 0.94);
+  border-radius: 12px;
+  padding: 9px 10px;
+  background: rgba(243, 250, 255, 0.92);
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.analytics-pill__label {
+  font-size: 11px;
+  font-weight: 700;
+  color: #577389;
+}
+
+.analytics-pill strong {
+  font-size: 15px;
+  color: #214a67;
+  letter-spacing: 0.01em;
 }
 
 .score-card {

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -143,9 +143,34 @@
         <button id="openOptionsBtn" class="button">Open Settings</button>
       </div>
     </section>
+
+    <section class="card">
+      <div class="profile-card__head">
+        <h2>Learning Analytics</h2>
+        <span class="profile-badge">Local only</span>
+      </div>
+      <p class="muted">Prompt text is not stored. This view tracks prompt metadata only.</p>
+      <div class="analytics-grid">
+        <article class="analytics-pill">
+          <span class="analytics-pill__label">Tracked prompts</span>
+          <strong id="analyticsPromptCount">0</strong>
+        </article>
+        <article class="analytics-pill">
+          <span class="analytics-pill__label">Average score</span>
+          <strong id="analyticsAverageScore">--</strong>
+        </article>
+        <article class="analytics-pill">
+          <span class="analytics-pill__label">Average length</span>
+          <strong id="analyticsAverageLength">--</strong>
+        </article>
+      </div>
+      <p id="analyticsSummary" class="stats"></p>
+      <p id="analyticsMeta" class="muted"></p>
+    </section>
   </main>
 
   <script src="../shared/promptQualityEngine.js"></script>
+  <script src="../shared/learningAnalytics.js"></script>
   <script src="../content/secretDetection.js"></script>
   <script src="../shared/promptLinter.js"></script>
   <script src="popup.js"></script>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -312,6 +312,11 @@ const scoreBreakdown = document.getElementById("scoreBreakdown");
 const scoreTips = document.getElementById("scoreTips");
 const promptLintSummary = document.getElementById("promptLintSummary");
 const lintResults = document.getElementById("lintResults");
+const analyticsPromptCount = document.getElementById("analyticsPromptCount");
+const analyticsAverageScore = document.getElementById("analyticsAverageScore");
+const analyticsAverageLength = document.getElementById("analyticsAverageLength");
+const analyticsSummary = document.getElementById("analyticsSummary");
+const analyticsMeta = document.getElementById("analyticsMeta");
 
 function storageGet(keys) {
   return new Promise((resolve) => chrome.storage.local.get(keys, resolve));
@@ -339,6 +344,14 @@ function getPromptLinter() {
     throw new Error("Prompt linter is unavailable.");
   }
   return linter;
+}
+
+function getLearningAnalytics() {
+  const analytics = window.AIDevCoachLearningAnalytics;
+  if (!analytics || typeof analytics.getSnapshot !== "function") {
+    throw new Error("Learning analytics engine is unavailable.");
+  }
+  return analytics;
 }
 
 function normalizeLevel(value) {
@@ -620,6 +633,81 @@ function renderStats(stats) {
   habitStats.textContent = `AI requests: ${stats.aiRequests} | Manual attempts: ${stats.manualAttempts} | Dependency: ${dependency}% | Bad prompts: ${stats.badPrompts} | Shortcut prompts: ${stats.shortcutPrompts} | Large pastes: ${stats.largePastes} | AI copies: ${stats.aiCopies} | Fast copies: ${stats.fastAiCopies}`;
 }
 
+function formatAnalyticsValue(value, suffix = "") {
+  return Number.isFinite(value) ? `${value}${suffix}` : "--";
+}
+
+function formatAnalyticsTime(timestamp) {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    return "No prompt tracked yet";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(timestamp));
+}
+
+function pickTopEntry(countMap) {
+  const entries = Object.entries(countMap || {});
+  if (entries.length === 0) {
+    return null;
+  }
+
+  entries.sort((left, right) => {
+    if (right[1] !== left[1]) {
+      return right[1] - left[1];
+    }
+    return left[0].localeCompare(right[0]);
+  });
+
+  const [label, count] = entries[0];
+  return { label, count };
+}
+
+function renderAnalyticsSnapshot(rawState) {
+  let snapshot = null;
+
+  try {
+    snapshot = getLearningAnalytics().getSnapshot(rawState);
+  } catch (error) {
+    analyticsPromptCount.textContent = "--";
+    analyticsAverageScore.textContent = "--";
+    analyticsAverageLength.textContent = "--";
+    analyticsSummary.textContent = "Learning analytics is unavailable in this popup build.";
+    analyticsMeta.textContent = "";
+    return;
+  }
+
+  analyticsPromptCount.textContent = String(snapshot.totalPrompts || 0);
+  analyticsAverageScore.textContent = formatAnalyticsValue(snapshot.averageScore, "/100");
+  analyticsAverageLength.textContent = formatAnalyticsValue(snapshot.averagePromptLength, " chars");
+
+  const topPlatform = pickTopEntry(snapshot.platformCounts);
+  const topSource = pickTopEntry(snapshot.sourceCounts);
+  const lastSeen = formatAnalyticsTime(snapshot.lastPromptAt);
+
+  analyticsSummary.textContent =
+    snapshot.totalPrompts > 0
+      ? `Last tracked prompt: ${snapshot.lastPlatform || "Unknown"} on ${lastSeen}.`
+      : "No prompt events tracked yet. Send a prompt from ChatGPT, Claude, Gemini, Grok, or DeepSeek to start analytics.";
+
+  const metaParts = [];
+  if (snapshot.scoredPrompts > 0) {
+    metaParts.push(`${snapshot.scoredPrompts} scored prompt${snapshot.scoredPrompts === 1 ? "" : "s"}`);
+  }
+  if (topPlatform) {
+    metaParts.push(`Top platform: ${topPlatform.label} (${topPlatform.count})`);
+  }
+  if (topSource) {
+    metaParts.push(`Top source: ${topSource.label.replace(/_/g, " ")} (${topSource.count})`);
+  }
+
+  analyticsMeta.textContent = metaParts.join(" | ") || "Stored locally for now. Future sync will build from this event history.";
+}
+
 function gradeClass(grade) {
   if (grade === "A") {
     return "grade--a";
@@ -865,6 +953,7 @@ async function loadState() {
     "settings",
     "profile",
     "stats",
+    "learningAnalytics",
     "selectedTemplate",
     "lastGeneratedPrompt",
     "lastPromptAnalysis",
@@ -890,6 +979,7 @@ async function loadState() {
   renderProfileView(profile, false);
   renderTemplates(selectedTemplate);
   renderStats(stats);
+  renderAnalyticsSnapshot(data.learningAnalytics);
   renderChecklist(readPromptForm());
 
   if (data.lastGeneratedPrompt) {

--- a/extension/shared/learningAnalytics.js
+++ b/extension/shared/learningAnalytics.js
@@ -1,0 +1,314 @@
+(() => {
+  const STORAGE_KEY = "learningAnalytics";
+  const SCHEMA_VERSION = 1;
+  const MAX_PROMPT_EVENTS = 250;
+  const DEFAULT_PLATFORM = "Unknown";
+  const DEFAULT_SOURCE = "composer_submit";
+
+  function clean(value) {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  function asNonNegativeInteger(value) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    return Math.max(0, Math.round(value));
+  }
+
+  function asPercentScore(value) {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    return Math.max(0, Math.min(100, Math.round(value)));
+  }
+
+  function normalizeTimestamp(value) {
+    if (Number.isFinite(value) && value > 0) {
+      return Math.round(value);
+    }
+    return Date.now();
+  }
+
+  function buildDayKey(timestamp) {
+    const date = new Date(timestamp);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  function makeCountMap(rawMap) {
+    if (!rawMap || typeof rawMap !== "object" || Array.isArray(rawMap)) {
+      return {};
+    }
+
+    return Object.entries(rawMap).reduce((accumulator, [key, value]) => {
+      const normalizedKey = clean(key);
+      const normalizedValue = asNonNegativeInteger(Number(value));
+      if (!normalizedKey || normalizedValue === null || normalizedValue === 0) {
+        return accumulator;
+      }
+      accumulator[normalizedKey] = normalizedValue;
+      return accumulator;
+    }, {});
+  }
+
+  function createEmptyState() {
+    return {
+      version: SCHEMA_VERSION,
+      promptEvents: [],
+      summary: {
+        totalPrompts: 0,
+        scoredPrompts: 0,
+        averageScore: null,
+        averagePromptLength: null,
+        lastPromptAt: 0,
+        lastPlatform: "",
+        platformCounts: {},
+        sourceCounts: {},
+        dayCounts: {}
+      },
+      updatedAt: 0
+    };
+  }
+
+  function normalizePromptEvent(input) {
+    if (!input || typeof input !== "object") {
+      return null;
+    }
+
+    const timestamp = normalizeTimestamp(input.timestamp || input.at);
+    const derivedPromptLength =
+      Number.isFinite(input.promptLength)
+        ? input.promptLength
+        : typeof input.prompt === "string"
+          ? input.prompt.length
+          : null;
+
+    return {
+      id: clean(input.id) || `prompt_${timestamp}_${Math.random().toString(36).slice(2, 8)}`,
+      type: "prompt_submitted",
+      source: clean(input.source) || DEFAULT_SOURCE,
+      platform: clean(input.platform) || DEFAULT_PLATFORM,
+      timestamp,
+      dayKey: buildDayKey(timestamp),
+      promptLength: asNonNegativeInteger(derivedPromptLength),
+      score: asPercentScore(input.score),
+      grade: clean(input.grade),
+      dependency: asPercentScore(input.dependency),
+      hasIndependentAttempt: !!input.hasIndependentAttempt,
+      hasShortcutIntent: !!input.hasShortcutIntent,
+      warningCount: asNonNegativeInteger(Number(input.warningCount)) || 0,
+      lintFailedCount: asNonNegativeInteger(Number(input.lintFailedCount)) || 0,
+      roleKey: clean(input.roleKey),
+      skillLevel: clean(input.skillLevel)
+    };
+  }
+
+  function summarizePromptEvents(promptEvents) {
+    const events = Array.isArray(promptEvents) ? promptEvents : [];
+    const platformCounts = {};
+    const sourceCounts = {};
+    const dayCounts = {};
+    let scoreTotal = 0;
+    let scoredPrompts = 0;
+    let promptLengthTotal = 0;
+    let promptLengthCount = 0;
+    let latestEvent = null;
+
+    events.forEach((event) => {
+      const platform = clean(event.platform) || DEFAULT_PLATFORM;
+      const source = clean(event.source) || DEFAULT_SOURCE;
+      const dayKey = clean(event.dayKey) || buildDayKey(normalizeTimestamp(event.timestamp));
+
+      platformCounts[platform] = (platformCounts[platform] || 0) + 1;
+      sourceCounts[source] = (sourceCounts[source] || 0) + 1;
+      dayCounts[dayKey] = (dayCounts[dayKey] || 0) + 1;
+
+      if (Number.isFinite(event.score)) {
+        scoreTotal += event.score;
+        scoredPrompts += 1;
+      }
+
+      if (Number.isFinite(event.promptLength)) {
+        promptLengthTotal += event.promptLength;
+        promptLengthCount += 1;
+      }
+
+      if (!latestEvent || event.timestamp > latestEvent.timestamp) {
+        latestEvent = event;
+      }
+    });
+
+    return {
+      totalPrompts: events.length,
+      scoredPrompts,
+      averageScore: scoredPrompts > 0 ? Math.round(scoreTotal / scoredPrompts) : null,
+      averagePromptLength: promptLengthCount > 0 ? Math.round(promptLengthTotal / promptLengthCount) : null,
+      lastPromptAt: latestEvent ? latestEvent.timestamp : 0,
+      lastPlatform: latestEvent ? latestEvent.platform : "",
+      platformCounts,
+      sourceCounts,
+      dayCounts
+    };
+  }
+
+  function coerceState(rawState) {
+    if (!rawState || typeof rawState !== "object" || Array.isArray(rawState)) {
+      return createEmptyState();
+    }
+
+    const promptEvents = Array.isArray(rawState.promptEvents)
+      ? rawState.promptEvents
+          .map((event) => normalizePromptEvent(event))
+          .filter(Boolean)
+          .sort((left, right) => left.timestamp - right.timestamp)
+          .slice(-MAX_PROMPT_EVENTS)
+      : [];
+
+    return {
+      version: SCHEMA_VERSION,
+      promptEvents,
+      summary: summarizePromptEvents(promptEvents),
+      updatedAt: Number.isFinite(rawState.updatedAt) ? Math.round(rawState.updatedAt) : 0
+    };
+  }
+
+  function appendPromptEvent(rawState, rawEvent) {
+    const state = coerceState(rawState);
+    const event = normalizePromptEvent(rawEvent);
+    if (!event) {
+      return state;
+    }
+
+    const promptEvents = [...state.promptEvents, event]
+      .sort((left, right) => left.timestamp - right.timestamp)
+      .slice(-MAX_PROMPT_EVENTS);
+
+    return {
+      version: SCHEMA_VERSION,
+      promptEvents,
+      summary: summarizePromptEvents(promptEvents),
+      updatedAt: Date.now()
+    };
+  }
+
+  function buildFutureSyncPayload(rawState, options = {}) {
+    const state = coerceState(rawState);
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt: Date.now(),
+      cursor: clean(options.cursor) || null,
+      promptEvents: state.promptEvents.map((event) => ({
+        clientEventId: event.id,
+        type: event.type,
+        source: event.source,
+        platform: event.platform,
+        timestamp: event.timestamp,
+        dayKey: event.dayKey,
+        promptLength: event.promptLength,
+        score: event.score,
+        grade: event.grade,
+        dependency: event.dependency,
+        hasIndependentAttempt: event.hasIndependentAttempt,
+        hasShortcutIntent: event.hasShortcutIntent,
+        warningCount: event.warningCount,
+        lintFailedCount: event.lintFailedCount,
+        roleKey: event.roleKey,
+        skillLevel: event.skillLevel
+      }))
+    };
+  }
+
+  function resolveStorageArea(storageArea) {
+    if (storageArea && typeof storageArea.get === "function" && typeof storageArea.set === "function") {
+      return storageArea;
+    }
+    if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
+      return chrome.storage.local;
+    }
+    return null;
+  }
+
+  function storageGet(storageArea, key) {
+    return new Promise((resolve, reject) => {
+      storageArea.get([key], (result) => {
+        if (typeof chrome !== "undefined" && chrome.runtime && chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        resolve(result ? result[key] : undefined);
+      });
+    });
+  }
+
+  function storageSet(storageArea, payload) {
+    return new Promise((resolve, reject) => {
+      storageArea.set(payload, () => {
+        if (typeof chrome !== "undefined" && chrome.runtime && chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  async function readState(storageArea) {
+    const resolvedStorage = resolveStorageArea(storageArea);
+    if (!resolvedStorage) {
+      return createEmptyState();
+    }
+    const rawState = await storageGet(resolvedStorage, STORAGE_KEY);
+    return coerceState(rawState);
+  }
+
+  async function writeState(storageArea, rawState) {
+    const resolvedStorage = resolveStorageArea(storageArea);
+    const nextState = coerceState(rawState);
+    nextState.updatedAt = Date.now();
+    if (!resolvedStorage) {
+      return nextState;
+    }
+    await storageSet(resolvedStorage, { [STORAGE_KEY]: nextState });
+    return nextState;
+  }
+
+  async function trackPromptEvent(storageArea, rawEvent) {
+    const state = await readState(storageArea);
+    const nextState = appendPromptEvent(state, rawEvent);
+    return writeState(storageArea, nextState);
+  }
+
+  function getSnapshot(rawState) {
+    return coerceState(rawState).summary;
+  }
+
+  const api = {
+    STORAGE_KEY,
+    SCHEMA_VERSION,
+    MAX_PROMPT_EVENTS,
+    createEmptyState,
+    normalizePromptEvent,
+    summarizePromptEvents,
+    coerceState,
+    appendPromptEvent,
+    buildFutureSyncPayload,
+    readState,
+    writeState,
+    trackPromptEvent,
+    getSnapshot,
+    makeCountMap
+  };
+
+  if (typeof window !== "undefined") {
+    window.AIDevCoachLearningAnalytics = api;
+  }
+  if (typeof globalThis !== "undefined") {
+    globalThis.AIDevCoachLearningAnalytics = api;
+  }
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - IntelliJ Plugin (Planned): 01-extensions/intellij-plugin.md
   - Product:
       - Feature Specification: 08-product/feature-spec.md
+      - Learning Analytics: 08-product/learning-analytics.md
       - Prompt Builder System: 08-product/prompt-builder-system.md
       - User Flow: 08-product/user-flow.md
   - Architecture:

--- a/scripts/test-learning-analytics.mjs
+++ b/scripts/test-learning-analytics.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const analytics = require("../extension/shared/learningAnalytics.js");
+
+function createMockStorage(initialValue) {
+  let state = initialValue;
+  return {
+    get(keys, callback) {
+      const key = Array.isArray(keys) ? keys[0] : keys;
+      callback({ [key]: state });
+    },
+    set(payload, callback) {
+      state = payload[analytics.STORAGE_KEY];
+      callback();
+    },
+    read() {
+      return state;
+    }
+  };
+}
+
+const mockStorage = createMockStorage(undefined);
+
+const weakEventState = await analytics.trackPromptEvent(mockStorage, {
+  source: "composer_submit",
+  platform: "ChatGPT",
+  promptLength: 18,
+  score: 42,
+  grade: "D",
+  dependency: 90,
+  hasIndependentAttempt: false,
+  hasShortcutIntent: true,
+  warningCount: 3,
+  lintFailedCount: 2,
+  roleKey: "software_engineer",
+  skillLevel: "Junior",
+  timestamp: Date.parse("2026-03-13T12:00:00Z")
+});
+
+const strongEventState = await analytics.trackPromptEvent(mockStorage, {
+  source: "quick_builder",
+  platform: "Claude",
+  promptLength: 420,
+  score: 88,
+  grade: "B",
+  dependency: 58,
+  hasIndependentAttempt: true,
+  hasShortcutIntent: false,
+  warningCount: 1,
+  lintFailedCount: 0,
+  roleKey: "software_engineer",
+  skillLevel: "Senior",
+  timestamp: Date.parse("2026-03-13T12:05:00Z")
+});
+
+assert.equal(weakEventState.summary.totalPrompts, 1, "first tracked event should increment total prompts");
+assert.equal(strongEventState.summary.totalPrompts, 2, "second tracked event should increment total prompts");
+assert.equal(strongEventState.summary.scoredPrompts, 2, "scored prompts should count numeric scores");
+assert.equal(strongEventState.summary.lastPlatform, "Claude", "last platform should reflect newest event");
+assert.equal(
+  strongEventState.summary.averageScore,
+  65,
+  "average score should round across stored prompt events"
+);
+assert.equal(
+  strongEventState.summary.platformCounts.ChatGPT,
+  1,
+  "platform counts should include the first platform"
+);
+assert.equal(
+  strongEventState.summary.sourceCounts.quick_builder,
+  1,
+  "source counts should include quick builder events"
+);
+
+const payload = analytics.buildFutureSyncPayload(mockStorage.read(), { cursor: "cursor_123" });
+assert.equal(payload.schemaVersion, analytics.SCHEMA_VERSION);
+assert.equal(payload.cursor, "cursor_123");
+assert.equal(payload.promptEvents.length, 2, "sync payload should include stored prompt events");
+assert.equal(payload.promptEvents[0].clientEventId.startsWith("prompt_"), true);
+assert.equal(payload.promptEvents[1].source, "quick_builder");
+assert.equal(payload.promptEvents[1].platform, "Claude");
+assert.equal(payload.promptEvents[1].skillLevel, "Senior");
+
+const snapshot = analytics.getSnapshot(mockStorage.read());
+assert.equal(snapshot.totalPrompts, 2, "snapshot should summarize the stored state");
+assert.equal(snapshot.averagePromptLength, 219, "average prompt length should be rounded");
+
+console.log("Learning analytics checks passed.");


### PR DESCRIPTION
## Summary
- add a shared learning analytics store for local prompt-session events
- track prompt submissions from monitor flows and show a popup analytics snapshot
- document the local schema/future sync contract and add CI smoke checks

## Validation
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- node scripts/test-learning-analytics.mjs
- python3 -m mkdocs build --strict
- node --check on all extension JS files

Refs #14
Refs #7