### PR TITLE
feat: add daily session summaries

### DIFF
--- a/docs/05-operations/monitoring.md
+++ b/docs/05-operations/monitoring.md
@@ -20,6 +20,7 @@ It tracks:
 
 - prompt source
 - AI platform
+- prompt category
 - timestamp
 - prompt length
 - prompt score / grade
@@ -28,6 +29,20 @@ It tracks:
 - lint failed count
 
 The event log does not store full prompt bodies. This keeps analytics useful for learning trends while preserving a conservative privacy boundary.
+
+## Daily session summary
+
+The popup derives a local daily session summary from the tracked prompt events.
+
+Current summary fields include:
+
+- total prompts for the selected day
+- average quality score
+- average prompt length
+- prompt category mix
+- independent-attempt rate
+- shortcut and lint-issue counts
+- up to three improvement suggestions
 
 ## Prompt Monitoring Modes
 

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added daily session summaries to learning analytics with prompt category breakdowns and friendly coaching suggestions
 - added local learning analytics event tracking for prompt submissions with popup snapshot summary
 - added future backend sync payload contract for prompt-session analytics rollout
 - added learning-analytics smoke checks in CI

--- a/docs/08-product/feature-spec.md
+++ b/docs/08-product/feature-spec.md
@@ -102,12 +102,13 @@ Live bubble behavior:
 
 ## 4.1 Learning Analytics (V2 Foundation)
 
-The first V2 analytics slice tracks prompt-session metadata locally.
+The first V2 analytics slice tracks prompt-session metadata locally and builds a daily summary from that history.
 
 Tracked prompt-event fields currently include:
 
 - prompt source (`composer_submit`, `quick_builder`, send-only variants)
 - platform
+- prompt category
 - timestamp
 - prompt length
 - prompt score and grade
@@ -123,6 +124,13 @@ Privacy defaults:
 - analytics history is stored locally in `chrome.storage.local`
 - prompt text is not stored in the analytics event log
 - future backend sync is documented but not enabled yet
+
+Daily summary output includes:
+
+- total prompts for today
+- average quality score
+- top prompt categories
+- readable coaching suggestions
 
 ## 5. Sensitive Data Guardrail
 

--- a/docs/08-product/learning-analytics.md
+++ b/docs/08-product/learning-analytics.md
@@ -1,6 +1,6 @@
 # Learning Analytics
 
-AI Dev Coach now includes the first V2 analytics foundation for prompt-session tracking.
+AI Dev Coach now includes the first V2 analytics foundation for prompt-session tracking and daily session summaries.
 
 This release is intentionally privacy-first:
 
@@ -17,6 +17,7 @@ Current event fields:
 - `type`: `prompt_submitted`
 - `source`: for example `composer_submit`, `composer_send_only`, `quick_builder`, `quick_builder_send_only`
 - `platform`: ChatGPT, Claude, Gemini, Grok, DeepSeek, or `Unknown`
+- `category`: Debugging, Code Review, System Design, Refactoring, Performance, Learning, or `Unclassified`
 - `timestamp`
 - `promptLength`
 - `score`
@@ -39,7 +40,19 @@ The popup now reads the local analytics store and shows a compact snapshot:
 - last platform used
 - top source / top platform
 
-This is the first step toward daily summaries and trend views in later V2 stories.
+## Daily session summary
+
+The popup now also builds a local daily session summary from tracked prompt events.
+
+Each daily summary includes:
+
+- total prompts for the day
+- average quality score
+- prompt category breakdown
+- independent-attempt rate
+- key improvement suggestions in friendly language
+
+This keeps the analytics useful for day-to-day reflection before the later trend-chart stories arrive.
 
 ## Storage model
 
@@ -47,7 +60,7 @@ The local analytics state is stored under the `learningAnalytics` key.
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "promptEvents": [],
   "summary": {
     "totalPrompts": 0,
@@ -58,6 +71,7 @@ The local analytics state is stored under the `learningAnalytics` key.
     "lastPlatform": "",
     "platformCounts": {},
     "sourceCounts": {},
+    "categoryCounts": {},
     "dayCounts": {}
   },
   "updatedAt": 0
@@ -74,7 +88,7 @@ Example payload:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "exportedAt": 1760000000000,
   "cursor": null,
   "promptEvents": [
@@ -83,6 +97,7 @@ Example payload:
       "type": "prompt_submitted",
       "source": "composer_submit",
       "platform": "ChatGPT",
+      "category": "debugging",
       "timestamp": 1760000000000,
       "dayKey": "2026-03-13",
       "promptLength": 312,

--- a/extension/content/monitor.js
+++ b/extension/content/monitor.js
@@ -1036,10 +1036,10 @@
 
     try {
       const nextState = await learningAnalytics.trackPromptEvent(chrome.storage.local, {
+        prompt,
         source: clean(options.source) || "composer_submit",
         platform: clean(options.platform) || clean(platform?.name) || "Unknown",
         timestamp: Date.now(),
-        promptLength: typeof prompt === "string" ? prompt.length : null,
         score: analysis && Number.isFinite(analysis.score) ? analysis.score : null,
         grade: clean(analysis?.grade || ""),
         dependency,

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -166,6 +166,18 @@
       </div>
       <p id="analyticsSummary" class="stats"></p>
       <p id="analyticsMeta" class="muted"></p>
+
+      <section class="score-card" aria-label="Daily session summary">
+        <div class="score-card__header">
+          <span>Today's Session</span>
+          <strong id="sessionSummaryScore">--/100</strong>
+          <span id="sessionSummaryDay" class="grade grade--na">Today</span>
+        </div>
+        <p id="sessionSummaryHeadline" class="muted"></p>
+        <p id="sessionSummaryStats" class="stats"></p>
+        <ul id="sessionCategoryList" class="score-list"></ul>
+        <ul id="sessionSuggestionList" class="score-list score-list--tips"></ul>
+      </section>
     </section>
   </main>
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -317,6 +317,12 @@ const analyticsAverageScore = document.getElementById("analyticsAverageScore");
 const analyticsAverageLength = document.getElementById("analyticsAverageLength");
 const analyticsSummary = document.getElementById("analyticsSummary");
 const analyticsMeta = document.getElementById("analyticsMeta");
+const sessionSummaryScore = document.getElementById("sessionSummaryScore");
+const sessionSummaryDay = document.getElementById("sessionSummaryDay");
+const sessionSummaryHeadline = document.getElementById("sessionSummaryHeadline");
+const sessionSummaryStats = document.getElementById("sessionSummaryStats");
+const sessionCategoryList = document.getElementById("sessionCategoryList");
+const sessionSuggestionList = document.getElementById("sessionSuggestionList");
 
 function storageGet(keys) {
   return new Promise((resolve) => chrome.storage.local.get(keys, resolve));
@@ -669,15 +675,25 @@ function pickTopEntry(countMap) {
 
 function renderAnalyticsSnapshot(rawState) {
   let snapshot = null;
+  let dailySummary = null;
 
   try {
-    snapshot = getLearningAnalytics().getSnapshot(rawState);
+    const analytics = getLearningAnalytics();
+    snapshot = analytics.getSnapshot(rawState);
+    dailySummary = analytics.buildDailySessionSummary(rawState);
   } catch (error) {
     analyticsPromptCount.textContent = "--";
     analyticsAverageScore.textContent = "--";
     analyticsAverageLength.textContent = "--";
     analyticsSummary.textContent = "Learning analytics is unavailable in this popup build.";
     analyticsMeta.textContent = "";
+    sessionSummaryScore.textContent = "--/100";
+    sessionSummaryDay.textContent = "Today";
+    sessionSummaryDay.className = "grade grade--na";
+    sessionSummaryHeadline.textContent = "";
+    sessionSummaryStats.textContent = "";
+    sessionCategoryList.innerHTML = "";
+    sessionSuggestionList.innerHTML = "";
     return;
   }
 
@@ -706,6 +722,67 @@ function renderAnalyticsSnapshot(rawState) {
   }
 
   analyticsMeta.textContent = metaParts.join(" | ") || "Stored locally for now. Future sync will build from this event history.";
+
+  renderDailySessionSummary(dailySummary);
+}
+
+function renderList(target, items, emptyText) {
+  target.innerHTML = "";
+
+  if (!Array.isArray(items) || items.length === 0) {
+    const item = document.createElement("li");
+    item.textContent = emptyText;
+    target.appendChild(item);
+    return;
+  }
+
+  items.forEach((entry) => {
+    const item = document.createElement("li");
+    item.textContent = entry;
+    target.appendChild(item);
+  });
+}
+
+function renderDailySessionSummary(summary) {
+  sessionSummaryDay.textContent = "Today";
+
+  if (!summary || summary.isEmpty) {
+    sessionSummaryScore.textContent = "--/100";
+    sessionSummaryDay.className = "grade grade--na";
+    sessionSummaryHeadline.textContent = "No prompts tracked today yet.";
+    sessionSummaryStats.textContent = "Send a prompt on a supported AI page to build your first daily summary.";
+    renderList(sessionCategoryList, [], "Prompt categories will appear here once today has activity.");
+    renderList(sessionSuggestionList, [], "Your next coaching suggestions will appear after the first prompt.");
+    return;
+  }
+
+  sessionSummaryScore.textContent = formatAnalyticsValue(summary.averageScore, "/100");
+  const summaryGrade = Number.isFinite(summary.averageScore)
+    ? summary.averageScore >= 85
+      ? "A"
+      : summary.averageScore >= 75
+        ? "B"
+        : summary.averageScore >= 60
+          ? "C"
+          : "D"
+    : "N/A";
+  sessionSummaryDay.className = `grade ${gradeClass(summaryGrade)}`;
+  sessionSummaryDay.textContent = summaryGrade;
+  sessionSummaryHeadline.textContent = summary.headline || "";
+  sessionSummaryStats.textContent = summary.statsLine || "";
+
+  renderList(
+    sessionCategoryList,
+    (summary.categories || []).slice(0, 3).map(
+      (category) => `${category.label}: ${category.count} prompt${category.count === 1 ? "" : "s"} (${category.percentage}%)`
+    ),
+    "Prompt categories will appear here once enough signals are available."
+  );
+  renderList(
+    sessionSuggestionList,
+    summary.suggestions || [],
+    "Great session. Keep using structured prompts with clear context and attempts."
+  );
 }
 
 function gradeClass(grade) {

--- a/extension/shared/learningAnalytics.js
+++ b/extension/shared/learningAnalytics.js
@@ -1,9 +1,101 @@
 (() => {
   const STORAGE_KEY = "learningAnalytics";
-  const SCHEMA_VERSION = 1;
+  const SCHEMA_VERSION = 2;
   const MAX_PROMPT_EVENTS = 250;
   const DEFAULT_PLATFORM = "Unknown";
   const DEFAULT_SOURCE = "composer_submit";
+  const DEFAULT_CATEGORY = "unclassified";
+  const CATEGORY_LABELS = {
+    debugging: "Debugging",
+    code_review: "Code Review",
+    system_design: "System Design",
+    refactoring: "Refactoring",
+    performance_optimization: "Performance",
+    learning: "Learning",
+    unclassified: "Unclassified"
+  };
+  const PROMPT_CATEGORY_RULES = [
+    {
+      key: "debugging",
+      patterns: [
+        /\bdebug(?:ging)?\b/i,
+        /\berror\b/i,
+        /\bstack\s*trace\b/i,
+        /\btraceback\b/i,
+        /\bexception\b/i,
+        /\bbug\b/i,
+        /\bfail(?:ed|ing|ure)?\b/i,
+        /\bcrash(?:ed)?\b/i,
+        /\broot cause\b/i,
+        /s[ửu]a\s+l[ỗo]i/i,
+        /l[ỗo]i/i
+      ]
+    },
+    {
+      key: "code_review",
+      patterns: [
+        /\breview\b/i,
+        /\bpull request\b/i,
+        /\bpr\b/i,
+        /\bregression\b/i,
+        /\bsecurity\b/i,
+        /\bmissing tests?\b/i,
+        /\bcode review\b/i
+      ]
+    },
+    {
+      key: "system_design",
+      patterns: [
+        /\barchitecture\b/i,
+        /\bsystem design\b/i,
+        /\bscal(?:e|ability|ing)\b/i,
+        /\bthroughput\b/i,
+        /\bavailability\b/i,
+        /\btrade-?off\b/i,
+        /\bnfr\b/i,
+        /\bsla\b/i,
+        /\bintegration\b/i
+      ]
+    },
+    {
+      key: "refactoring",
+      patterns: [
+        /\brefactor(?:ing)?\b/i,
+        /\bmaintainab(?:le|ility)\b/i,
+        /\breadability\b/i,
+        /\bcode smell\b/i,
+        /\bcleanup\b/i,
+        /\bstructure\b/i
+      ]
+    },
+    {
+      key: "performance_optimization",
+      patterns: [
+        /\bperformance\b/i,
+        /\blatency\b/i,
+        /\bthroughput\b/i,
+        /\bmemory\b/i,
+        /\bcpu\b/i,
+        /\bbenchmark\b/i,
+        /\boptimi(?:ze|sation|zation)\b/i,
+        /\bslow query\b/i
+      ]
+    },
+    {
+      key: "learning",
+      patterns: [
+        /\blearn(?:ing)?\b/i,
+        /\bteach\b/i,
+        /\bexplain\b/i,
+        /\bunderstand\b/i,
+        /\bconcept\b/i,
+        /\bguide(?:d)?\b/i,
+        /\bexercise\b/i,
+        /\bh[ọo]c/i,
+        /gi[ảa]i\s+th[íi]ch/i
+      ]
+    }
+  ];
 
   function clean(value) {
     return typeof value === "string" ? value.trim() : "";
@@ -38,13 +130,13 @@
     return `${year}-${month}-${day}`;
   }
 
-  function makeCountMap(rawMap) {
+  function makeCountMap(rawMap, normalizeKey = (key) => clean(key)) {
     if (!rawMap || typeof rawMap !== "object" || Array.isArray(rawMap)) {
       return {};
     }
 
     return Object.entries(rawMap).reduce((accumulator, [key, value]) => {
-      const normalizedKey = clean(key);
+      const normalizedKey = normalizeKey(key);
       const normalizedValue = asNonNegativeInteger(Number(value));
       if (!normalizedKey || normalizedValue === null || normalizedValue === 0) {
         return accumulator;
@@ -52,6 +144,50 @@
       accumulator[normalizedKey] = normalizedValue;
       return accumulator;
     }, {});
+  }
+
+  function normalizeCategory(value) {
+    const normalized = clean(value).toLowerCase();
+    return CATEGORY_LABELS[normalized] ? normalized : DEFAULT_CATEGORY;
+  }
+
+  function getCategoryLabel(value) {
+    const key = normalizeCategory(value);
+    return CATEGORY_LABELS[key] || CATEGORY_LABELS[DEFAULT_CATEGORY];
+  }
+
+  function countRuleMatches(text, rule) {
+    if (!rule || !Array.isArray(rule.patterns)) {
+      return 0;
+    }
+
+    return rule.patterns.reduce((count, pattern) => count + Number(pattern.test(text)), 0);
+  }
+
+  function inferPromptCategory(input) {
+    const options = typeof input === "string" ? { prompt: input } : { ...(input || {}) };
+    const explicitCategory = normalizeCategory(options.category);
+    if (explicitCategory !== DEFAULT_CATEGORY) {
+      return explicitCategory;
+    }
+
+    const prompt = clean(options.prompt);
+    if (!prompt) {
+      return DEFAULT_CATEGORY;
+    }
+
+    let bestCategory = DEFAULT_CATEGORY;
+    let bestScore = 0;
+
+    PROMPT_CATEGORY_RULES.forEach((rule) => {
+      const score = countRuleMatches(prompt, rule);
+      if (score > bestScore) {
+        bestCategory = rule.key;
+        bestScore = score;
+      }
+    });
+
+    return bestCategory;
   }
 
   function createEmptyState() {
@@ -67,7 +203,17 @@
         lastPlatform: "",
         platformCounts: {},
         sourceCounts: {},
-        dayCounts: {}
+        categoryCounts: {},
+        dayCounts: {},
+        qualityCounts: {
+          strong: 0,
+          solid: 0,
+          needsWork: 0
+        },
+        independentAttemptRate: null,
+        shortcutPromptCount: 0,
+        lintIssueEvents: 0,
+        warningEvents: 0
       },
       updatedAt: 0
     };
@@ -79,18 +225,24 @@
     }
 
     const timestamp = normalizeTimestamp(input.timestamp || input.at);
+    const prompt = clean(input.prompt);
     const derivedPromptLength =
       Number.isFinite(input.promptLength)
         ? input.promptLength
-        : typeof input.prompt === "string"
-          ? input.prompt.length
+        : prompt
+          ? prompt.length
           : null;
+    const category = inferPromptCategory({
+      prompt,
+      category: input.category
+    });
 
     return {
       id: clean(input.id) || `prompt_${timestamp}_${Math.random().toString(36).slice(2, 8)}`,
       type: "prompt_submitted",
       source: clean(input.source) || DEFAULT_SOURCE,
       platform: clean(input.platform) || DEFAULT_PLATFORM,
+      category,
       timestamp,
       dayKey: buildDayKey(timestamp),
       promptLength: asNonNegativeInteger(derivedPromptLength),
@@ -110,25 +262,57 @@
     const events = Array.isArray(promptEvents) ? promptEvents : [];
     const platformCounts = {};
     const sourceCounts = {};
+    const categoryCounts = {};
     const dayCounts = {};
+    const qualityCounts = {
+      strong: 0,
+      solid: 0,
+      needsWork: 0
+    };
     let scoreTotal = 0;
     let scoredPrompts = 0;
     let promptLengthTotal = 0;
     let promptLengthCount = 0;
     let latestEvent = null;
+    let independentAttemptCount = 0;
+    let shortcutPromptCount = 0;
+    let lintIssueEvents = 0;
+    let warningEvents = 0;
 
     events.forEach((event) => {
       const platform = clean(event.platform) || DEFAULT_PLATFORM;
       const source = clean(event.source) || DEFAULT_SOURCE;
+      const category = normalizeCategory(event.category);
       const dayKey = clean(event.dayKey) || buildDayKey(normalizeTimestamp(event.timestamp));
 
       platformCounts[platform] = (platformCounts[platform] || 0) + 1;
       sourceCounts[source] = (sourceCounts[source] || 0) + 1;
+      categoryCounts[category] = (categoryCounts[category] || 0) + 1;
       dayCounts[dayKey] = (dayCounts[dayKey] || 0) + 1;
+
+      if (event.hasIndependentAttempt) {
+        independentAttemptCount += 1;
+      }
+      if (event.hasShortcutIntent) {
+        shortcutPromptCount += 1;
+      }
+      if (event.lintFailedCount > 0) {
+        lintIssueEvents += 1;
+      }
+      if (event.warningCount > 0) {
+        warningEvents += 1;
+      }
 
       if (Number.isFinite(event.score)) {
         scoreTotal += event.score;
         scoredPrompts += 1;
+        if (event.score >= 85) {
+          qualityCounts.strong += 1;
+        } else if (event.score >= 60) {
+          qualityCounts.solid += 1;
+        } else {
+          qualityCounts.needsWork += 1;
+        }
       }
 
       if (Number.isFinite(event.promptLength)) {
@@ -150,7 +334,14 @@
       lastPlatform: latestEvent ? latestEvent.platform : "",
       platformCounts,
       sourceCounts,
-      dayCounts
+      categoryCounts,
+      dayCounts,
+      qualityCounts,
+      independentAttemptRate:
+        events.length > 0 ? Math.round((independentAttemptCount / events.length) * 100) : null,
+      shortcutPromptCount,
+      lintIssueEvents,
+      warningEvents
     };
   }
 
@@ -194,6 +385,131 @@
     };
   }
 
+  function rankCountMap(countMap, total, labelResolver = (key) => key) {
+    const safeTotal = Math.max(0, asNonNegativeInteger(total) || 0);
+    return Object.entries(countMap || {})
+      .filter(([, count]) => Number.isFinite(count) && count > 0)
+      .sort((left, right) => {
+        if (right[1] !== left[1]) {
+          return right[1] - left[1];
+        }
+        return left[0].localeCompare(right[0]);
+      })
+      .map(([key, count]) => ({
+        key,
+        label: labelResolver(key),
+        count,
+        percentage: safeTotal > 0 ? Math.round((count / safeTotal) * 100) : 0
+      }));
+  }
+
+  function pushUnique(target, message) {
+    if (!message || target.includes(message)) {
+      return;
+    }
+    target.push(message);
+  }
+
+  function buildSessionSuggestions(summary, topCategory) {
+    const suggestions = [];
+
+    if (!summary || summary.totalPrompts === 0) {
+      pushUnique(suggestions, "Send a few prompts during a real task to unlock your first daily summary.");
+      return suggestions;
+    }
+
+    if (!Number.isFinite(summary.averageScore) || summary.averageScore < 75) {
+      pushUnique(suggestions, "Add stronger evidence: error details, expected vs actual behavior, and one concrete artifact.");
+    }
+
+    if (!Number.isFinite(summary.independentAttemptRate) || summary.independentAttemptRate < 50) {
+      pushUnique(suggestions, "Describe what you already tried and where you are blocked before sending prompts to AI.");
+    }
+
+    if (summary.shortcutPromptCount > 0) {
+      pushUnique(suggestions, "Ask AI for hints, review, or next steps before asking for a final answer or full code.");
+    }
+
+    if (summary.lintIssueEvents > 0) {
+      pushUnique(suggestions, "Review prompt lint warnings before sending. They usually point to missing context or vague asks.");
+    }
+
+    if (Number.isFinite(summary.averagePromptLength) && summary.averagePromptLength < 120) {
+      pushUnique(suggestions, "Prompts are short on average. Add file paths, logs, snippets, or success criteria.");
+    }
+
+    if (topCategory && topCategory.key === DEFAULT_CATEGORY && summary.totalPrompts >= 2) {
+      pushUnique(suggestions, "Use clearer task framing so your sessions are easier to categorize and review over time.");
+    }
+
+    if (suggestions.length === 0) {
+      pushUnique(suggestions, "Strong session. Keep using Task, Context, and What You Tried in every prompt.");
+    }
+
+    return suggestions.slice(0, 3);
+  }
+
+  function buildSessionHeadline(dayKey, summary, topCategory) {
+    if (!summary || summary.totalPrompts === 0) {
+      return `No prompts tracked for ${dayKey} yet.`;
+    }
+
+    const averageScoreText = Number.isFinite(summary.averageScore)
+      ? ` Average quality score: ${summary.averageScore}/100.`
+      : "";
+    const categoryText = topCategory && topCategory.key !== DEFAULT_CATEGORY
+      ? ` Most prompts were ${topCategory.label.toLowerCase()}.`
+      : "";
+
+    return `You sent ${summary.totalPrompts} prompt${summary.totalPrompts === 1 ? "" : "s"} on ${dayKey}.${averageScoreText}${categoryText}`;
+  }
+
+  function buildSessionStatsLine(summary, topCategory) {
+    if (!summary || summary.totalPrompts === 0) {
+      return "Daily summaries appear after your first tracked prompt of the day.";
+    }
+
+    const parts = [];
+
+    if (topCategory) {
+      parts.push(`Top category: ${topCategory.label} (${topCategory.count})`);
+    }
+    if (Number.isFinite(summary.independentAttemptRate)) {
+      parts.push(`Independent attempts: ${summary.independentAttemptRate}%`);
+    }
+    if (summary.lintIssueEvents > 0) {
+      parts.push(`Lint issue events: ${summary.lintIssueEvents}`);
+    }
+    if (summary.shortcutPromptCount > 0) {
+      parts.push(`Shortcut prompts: ${summary.shortcutPromptCount}`);
+    }
+
+    return parts.join(" | ") || "Keep building structured prompts to improve this summary.";
+  }
+
+  function buildDailySessionSummary(rawState, options = {}) {
+    const state = coerceState(rawState);
+    const targetTimestamp = normalizeTimestamp(options.timestamp || options.now);
+    const dayKey = clean(options.dayKey) || buildDayKey(targetTimestamp);
+    const promptEvents = state.promptEvents.filter((event) => event.dayKey === dayKey);
+    const summary = summarizePromptEvents(promptEvents);
+    const categories = rankCountMap(summary.categoryCounts, summary.totalPrompts, getCategoryLabel);
+    const topCategory = categories[0] || null;
+    const suggestions = buildSessionSuggestions(summary, topCategory);
+
+    return {
+      dayKey,
+      generatedAt: Date.now(),
+      isEmpty: summary.totalPrompts === 0,
+      categories,
+      topCategory,
+      headline: buildSessionHeadline(dayKey, summary, topCategory),
+      statsLine: buildSessionStatsLine(summary, topCategory),
+      suggestions,
+      ...summary
+    };
+  }
+
   function buildFutureSyncPayload(rawState, options = {}) {
     const state = coerceState(rawState);
     return {
@@ -205,6 +521,7 @@
         type: event.type,
         source: event.source,
         platform: event.platform,
+        category: event.category,
         timestamp: event.timestamp,
         dayKey: event.dayKey,
         promptLength: event.promptLength,
@@ -289,16 +606,21 @@
     STORAGE_KEY,
     SCHEMA_VERSION,
     MAX_PROMPT_EVENTS,
+    DEFAULT_CATEGORY,
+    CATEGORY_LABELS,
     createEmptyState,
     normalizePromptEvent,
     summarizePromptEvents,
     coerceState,
     appendPromptEvent,
+    buildDailySessionSummary,
     buildFutureSyncPayload,
     readState,
     writeState,
     trackPromptEvent,
     getSnapshot,
+    getCategoryLabel,
+    inferPromptCategory,
     makeCountMap
   };
 

--- a/scripts/test-learning-analytics.mjs
+++ b/scripts/test-learning-analytics.mjs
@@ -25,10 +25,17 @@ function createMockStorage(initialValue) {
 
 const mockStorage = createMockStorage(undefined);
 
-const weakEventState = await analytics.trackPromptEvent(mockStorage, {
+await analytics.trackPromptEvent(mockStorage, {
+  prompt: [
+    "Debug task: fix a failing React checkout form submit.",
+    "Context: clicking submit throws TypeError in CheckoutForm.tsx:87.",
+    "Expected: create an order and redirect.",
+    "Actual: request never reaches POST /api/orders.",
+    "What I tried: logged the payload and added a guard.",
+    "Blocker: not sure whether the bug is in form state or mapper."
+  ].join("\n"),
   source: "composer_submit",
   platform: "ChatGPT",
-  promptLength: 18,
   score: 42,
   grade: "D",
   dependency: 90,
@@ -41,10 +48,15 @@ const weakEventState = await analytics.trackPromptEvent(mockStorage, {
   timestamp: Date.parse("2026-03-13T12:00:00Z")
 });
 
-const strongEventState = await analytics.trackPromptEvent(mockStorage, {
+const secondState = await analytics.trackPromptEvent(mockStorage, {
+  prompt: [
+    "Learning goal: explain the JavaScript event loop.",
+    "Context: I understand promises but still confuse macrotasks vs microtasks.",
+    "What I tried: I read docs and ran a simple example.",
+    "Acceptance criteria: give one short exercise and a recap."
+  ].join("\n"),
   source: "quick_builder",
   platform: "Claude",
-  promptLength: 420,
   score: 88,
   grade: "B",
   dependency: 58,
@@ -57,37 +69,66 @@ const strongEventState = await analytics.trackPromptEvent(mockStorage, {
   timestamp: Date.parse("2026-03-13T12:05:00Z")
 });
 
-assert.equal(weakEventState.summary.totalPrompts, 1, "first tracked event should increment total prompts");
-assert.equal(strongEventState.summary.totalPrompts, 2, "second tracked event should increment total prompts");
-assert.equal(strongEventState.summary.scoredPrompts, 2, "scored prompts should count numeric scores");
-assert.equal(strongEventState.summary.lastPlatform, "Claude", "last platform should reflect newest event");
-assert.equal(
-  strongEventState.summary.averageScore,
-  65,
-  "average score should round across stored prompt events"
-);
-assert.equal(
-  strongEventState.summary.platformCounts.ChatGPT,
-  1,
-  "platform counts should include the first platform"
-);
-assert.equal(
-  strongEventState.summary.sourceCounts.quick_builder,
-  1,
-  "source counts should include quick builder events"
-);
+await analytics.trackPromptEvent(mockStorage, {
+  prompt: [
+    "System design question: design a queue-backed notification pipeline.",
+    "Context: high throughput, retries, observability, and cost constraints."
+  ].join("\n"),
+  source: "composer_submit",
+  platform: "Gemini",
+  score: 79,
+  grade: "B",
+  dependency: 65,
+  hasIndependentAttempt: true,
+  hasShortcutIntent: false,
+  warningCount: 0,
+  lintFailedCount: 0,
+  roleKey: "solution_architecture",
+  skillLevel: "Senior",
+  timestamp: Date.parse("2026-03-12T12:00:00Z")
+});
+
+assert.equal(secondState.summary.totalPrompts, 2, "second tracked event should increment total prompts");
 
 const payload = analytics.buildFutureSyncPayload(mockStorage.read(), { cursor: "cursor_123" });
 assert.equal(payload.schemaVersion, analytics.SCHEMA_VERSION);
 assert.equal(payload.cursor, "cursor_123");
-assert.equal(payload.promptEvents.length, 2, "sync payload should include stored prompt events");
+assert.equal(payload.promptEvents.length, 3, "sync payload should include stored prompt events");
 assert.equal(payload.promptEvents[0].clientEventId.startsWith("prompt_"), true);
-assert.equal(payload.promptEvents[1].source, "quick_builder");
-assert.equal(payload.promptEvents[1].platform, "Claude");
-assert.equal(payload.promptEvents[1].skillLevel, "Senior");
+const quickBuilderEvent = payload.promptEvents.find((event) => event.source === "quick_builder");
+const systemDesignEvent = payload.promptEvents.find((event) => event.category === "system_design");
+assert.ok(quickBuilderEvent, "payload should include the quick builder event");
+assert.ok(systemDesignEvent, "payload should include the system design event");
+assert.equal(quickBuilderEvent.platform, "Claude");
+assert.equal(quickBuilderEvent.category, "learning");
+assert.equal(systemDesignEvent.platform, "Gemini");
 
 const snapshot = analytics.getSnapshot(mockStorage.read());
-assert.equal(snapshot.totalPrompts, 2, "snapshot should summarize the stored state");
-assert.equal(snapshot.averagePromptLength, 219, "average prompt length should be rounded");
+assert.equal(snapshot.totalPrompts, 3, "snapshot should summarize the stored state");
+assert.equal(snapshot.scoredPrompts, 3, "all events have scores in this smoke test");
+assert.equal(snapshot.lastPlatform, "Claude", "latest event should still define last platform");
+assert.equal(snapshot.categoryCounts.debugging, 1, "debugging category should be tracked");
+assert.equal(snapshot.categoryCounts.learning, 1, "learning category should be tracked");
+assert.equal(snapshot.categoryCounts.system_design, 1, "system design category should be tracked");
+
+const currentDayKey = quickBuilderEvent.dayKey;
+const dailySummary = analytics.buildDailySessionSummary(mockStorage.read(), { dayKey: currentDayKey });
+
+assert.equal(dailySummary.dayKey, currentDayKey);
+assert.equal(dailySummary.totalPrompts, 2, "daily summary should filter to the requested day");
+assert.equal(dailySummary.averageScore, 65, "daily summary should average only selected-day prompts");
+assert.equal(dailySummary.topCategory.key, "debugging", "daily summary should rank categories by usage");
+assert.ok(
+  dailySummary.categories.some((category) => category.key === "learning"),
+  "daily summary should include per-category counts"
+);
+assert.ok(
+  dailySummary.suggestions.some((message) => message.includes("Add stronger evidence")),
+  "daily summary should include coaching suggestions when quality is weak"
+);
+assert.ok(
+  dailySummary.headline.includes("Average quality score: 65/100"),
+  "daily summary headline should be readable for end users"
+);
 
 console.log("Learning analytics checks passed.");


### PR DESCRIPTION
## Summary
- extend local learning analytics with prompt categories and daily session summaries
- show a compact Today summary in the popup with category mix and coaching tips
- document the updated analytics contract and strengthen smoke coverage

## Validation
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- node scripts/test-learning-analytics.mjs
- python3 -m mkdocs build --strict
- node --check on all extension JS files

Refs #15
Refs #7