### PR TITLE
feat(analytics): add skill trend dashboard

### DIFF
--- a/docs/05-operations/monitoring.md
+++ b/docs/05-operations/monitoring.md
@@ -44,6 +44,18 @@ Current summary fields include:
 - shortcut and lint-issue counts
 - up to three improvement suggestions
 
+## Trend dashboard rules
+
+The analytics popup also exposes a recent-window trend dashboard.
+
+Current rules:
+
+- quality trend = daily average of scored prompt events
+- warning trend = daily count of prompt events with `warningCount > 0`
+- category trend = prompt-category mix across the selected local window
+
+These rules are derived in shared analytics code so popup visuals and future analytics surfaces stay consistent.
+
 ## Prompt Monitoring Modes
 
 - `draft` analysis: runs on input debounce (500ms) for realtime score preview

--- a/docs/07-project/changelog.md
+++ b/docs/07-project/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added a lightweight local trend dashboard with quality-over-time, warning-frequency, and prompt-category views
 - added daily session summaries to learning analytics with prompt category breakdowns and friendly coaching suggestions
 - added local learning analytics event tracking for prompt submissions with popup snapshot summary
 - added future backend sync payload contract for prompt-session analytics rollout

--- a/docs/08-product/feature-spec.md
+++ b/docs/08-product/feature-spec.md
@@ -132,6 +132,13 @@ Daily summary output includes:
 - top prompt categories
 - readable coaching suggestions
 
+Trend dashboard output includes:
+
+- 7-day quality trend
+- warning frequency trend
+- prompt category mix view
+- explainable calculation rules shown in the UI copy/docs
+
 ## 5. Sensitive Data Guardrail
 
 Before a prompt is sent, the extension can scan for likely secrets such as:

--- a/docs/08-product/learning-analytics.md
+++ b/docs/08-product/learning-analytics.md
@@ -54,6 +54,24 @@ Each daily summary includes:
 
 This keeps the analytics useful for day-to-day reflection before the later trend-chart stories arrive.
 
+## Trend dashboard
+
+The popup now includes a lightweight local trend dashboard for the recent activity window.
+
+Current trend views:
+
+- quality over time: daily average prompt score
+- warning frequency trend: number of prompt events per day that triggered warnings
+- prompt type breakdown: category mix across the visible window
+
+Trend rules stay explicit and local-first:
+
+- quality trend uses the average score of scored prompt events for each day
+- warning trend counts prompt events that emitted one or more warnings
+- category bars group events into Debugging, Code Review, System Design, Refactoring, Performance, Learning, or Unclassified
+
+The first release keeps the dashboard lightweight and fully local in the popup.
+
 ## Storage model
 
 The local analytics state is stored under the `learningAnalytics` key.

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -393,6 +393,95 @@ textarea {
   letter-spacing: 0.01em;
 }
 
+.trend-panel {
+  border: 1px solid rgba(182, 214, 234, 0.82);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 9px 10px;
+  display: grid;
+  gap: 7px;
+}
+
+.trend-panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 800;
+  color: #244960;
+}
+
+.trend-chart {
+  width: 100%;
+  height: 84px;
+  display: block;
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, rgba(195, 238, 250, 0.22), rgba(255, 255, 255, 0.2)),
+    rgba(243, 250, 255, 0.85);
+  border: 1px solid rgba(195, 222, 240, 0.92);
+}
+
+.trend-delta {
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 800;
+  background: #edf6fc;
+  color: #5b7386;
+}
+
+.trend-delta--up {
+  background: #daf6e9;
+  color: #0b7d52;
+}
+
+.trend-delta--down {
+  background: #fde9e8;
+  color: #b1231a;
+}
+
+.trend-delta--steady {
+  background: #edf6fc;
+  color: #5b7386;
+}
+
+.category-bars {
+  display: grid;
+  gap: 8px;
+}
+
+.category-bar {
+  display: grid;
+  gap: 4px;
+}
+
+.category-bar__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  color: #31526a;
+}
+
+.category-bar__track {
+  position: relative;
+  overflow: hidden;
+  border-radius: 999px;
+  height: 10px;
+  background: rgba(205, 227, 242, 0.84);
+}
+
+.category-bar__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--secondary), var(--primary-strong));
+}
+
 .score-card {
   border: 1px solid rgba(176, 213, 236, 0.94);
   border-radius: 12px;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -178,6 +178,38 @@
         <ul id="sessionCategoryList" class="score-list"></ul>
         <ul id="sessionSuggestionList" class="score-list score-list--tips"></ul>
       </section>
+
+      <section class="score-card" aria-label="Trend dashboard">
+        <div class="score-card__header">
+          <span>Trend Dashboard</span>
+          <strong id="trendWindowLabel">7 days</strong>
+          <span id="trendActiveDays" class="grade grade--na">0 active</span>
+        </div>
+        <div class="trend-panel">
+          <div class="trend-panel__head">
+            <span>Quality over time</span>
+            <span id="qualityTrendDelta" class="trend-delta">--</span>
+          </div>
+          <svg id="qualityTrendChart" class="trend-chart" viewBox="0 0 220 84" role="img" aria-label="Prompt quality trend"></svg>
+          <p id="qualityTrendSummary" class="muted"></p>
+        </div>
+        <div class="trend-panel">
+          <div class="trend-panel__head">
+            <span>Warning frequency</span>
+            <span id="warningTrendDelta" class="trend-delta">--</span>
+          </div>
+          <svg id="warningTrendChart" class="trend-chart" viewBox="0 0 220 84" role="img" aria-label="Warning frequency trend"></svg>
+          <p id="warningTrendSummary" class="muted"></p>
+        </div>
+        <div class="trend-panel">
+          <div class="trend-panel__head">
+            <span>Prompt types</span>
+            <span id="trendTopCategory" class="trend-delta">--</span>
+          </div>
+          <div id="categoryTrendBars" class="category-bars"></div>
+          <p id="trendRulesSummary" class="muted"></p>
+        </div>
+      </section>
     </section>
   </main>
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -323,6 +323,17 @@ const sessionSummaryHeadline = document.getElementById("sessionSummaryHeadline")
 const sessionSummaryStats = document.getElementById("sessionSummaryStats");
 const sessionCategoryList = document.getElementById("sessionCategoryList");
 const sessionSuggestionList = document.getElementById("sessionSuggestionList");
+const trendWindowLabel = document.getElementById("trendWindowLabel");
+const trendActiveDays = document.getElementById("trendActiveDays");
+const qualityTrendDelta = document.getElementById("qualityTrendDelta");
+const qualityTrendChart = document.getElementById("qualityTrendChart");
+const qualityTrendSummary = document.getElementById("qualityTrendSummary");
+const warningTrendDelta = document.getElementById("warningTrendDelta");
+const warningTrendChart = document.getElementById("warningTrendChart");
+const warningTrendSummary = document.getElementById("warningTrendSummary");
+const trendTopCategory = document.getElementById("trendTopCategory");
+const categoryTrendBars = document.getElementById("categoryTrendBars");
+const trendRulesSummary = document.getElementById("trendRulesSummary");
 
 function storageGet(keys) {
   return new Promise((resolve) => chrome.storage.local.get(keys, resolve));
@@ -354,7 +365,11 @@ function getPromptLinter() {
 
 function getLearningAnalytics() {
   const analytics = window.AIDevCoachLearningAnalytics;
-  if (!analytics || typeof analytics.getSnapshot !== "function") {
+  if (
+    !analytics ||
+    typeof analytics.getSnapshot !== "function" ||
+    typeof analytics.buildTrendDashboard !== "function"
+  ) {
     throw new Error("Learning analytics engine is unavailable.");
   }
   return analytics;
@@ -673,14 +688,228 @@ function pickTopEntry(countMap) {
   return { label, count };
 }
 
+function renderEmptyTrendChart(target, message) {
+  target.innerHTML = `<text x="110" y="46" text-anchor="middle" font-size="11" fill="#6b8597">${message}</text>`;
+}
+
+function buildLineChartMarkup(series, getValue, options = {}) {
+  const width = 220;
+  const height = 84;
+  const paddingX = 14;
+  const paddingTop = 10;
+  const paddingBottom = 20;
+  const chartHeight = height - paddingTop - paddingBottom;
+  const maxValue = Number.isFinite(options.maxValue) ? options.maxValue : 100;
+  const validSeries = series.filter((entry) => Number.isFinite(getValue(entry)));
+
+  if (validSeries.length === 0) {
+    return null;
+  }
+
+  const xForIndex = (index) =>
+    series.length === 1 ? width / 2 : paddingX + (index * (width - paddingX * 2)) / (series.length - 1);
+  const yForValue = (value) =>
+    height - paddingBottom - (Math.max(0, Math.min(maxValue, value)) / maxValue) * chartHeight;
+
+  const guides = [0.25, 0.5, 0.75]
+    .map((ratio) => {
+      const y = paddingTop + chartHeight * ratio;
+      return `<line x1="${paddingX}" y1="${y}" x2="${width - paddingX}" y2="${y}" stroke="rgba(123, 170, 204, 0.18)" stroke-width="1" />`;
+    })
+    .join("");
+
+  const segments = [];
+  let currentSegment = [];
+
+  series.forEach((entry, index) => {
+    const value = getValue(entry);
+    if (!Number.isFinite(value)) {
+      if (currentSegment.length > 0) {
+        segments.push(currentSegment);
+        currentSegment = [];
+      }
+      return;
+    }
+    currentSegment.push(`${xForIndex(index)},${yForValue(value)}`);
+  });
+
+  if (currentSegment.length > 0) {
+    segments.push(currentSegment);
+  }
+
+  const polylines = segments
+    .map(
+      (segment) =>
+        `<polyline fill="none" stroke="${options.stroke || "#4b8fbe"}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" points="${segment.join(" ")}" />`
+    )
+    .join("");
+
+  const dots = series
+    .map((entry, index) => {
+      const value = getValue(entry);
+      if (!Number.isFinite(value)) {
+        return "";
+      }
+      return `<circle cx="${xForIndex(index)}" cy="${yForValue(value)}" r="3.2" fill="${options.dotFill || "#2a648f"}" />`;
+    })
+    .join("");
+
+  const labels = series
+    .map((entry, index) => {
+      const dayLabel = entry.dayKey ? entry.dayKey.slice(8) : String(index + 1);
+      return `<text x="${xForIndex(index)}" y="${height - 5}" text-anchor="middle" font-size="9" fill="#6b8597">${dayLabel}</text>`;
+    })
+    .join("");
+
+  return `${guides}${polylines}${dots}${labels}`;
+}
+
+function buildBarChartMarkup(series, getValue, options = {}) {
+  const width = 220;
+  const height = 84;
+  const paddingX = 14;
+  const paddingTop = 10;
+  const paddingBottom = 20;
+  const chartHeight = height - paddingTop - paddingBottom;
+  const values = series.map((entry) => getValue(entry)).filter((value) => Number.isFinite(value));
+  const maxValue = Math.max(Number.isFinite(options.maxValue) ? options.maxValue : 0, ...values, 1);
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  const gap = 6;
+  const barWidth = Math.max(10, (width - paddingX * 2 - gap * Math.max(0, series.length - 1)) / Math.max(1, series.length));
+
+  const guides = [0.25, 0.5, 0.75]
+    .map((ratio) => {
+      const y = paddingTop + chartHeight * ratio;
+      return `<line x1="${paddingX}" y1="${y}" x2="${width - paddingX}" y2="${y}" stroke="rgba(123, 170, 204, 0.18)" stroke-width="1" />`;
+    })
+    .join("");
+
+  const bars = series
+    .map((entry, index) => {
+      const value = getValue(entry);
+      const x = paddingX + index * (barWidth + gap);
+      const normalized = Number.isFinite(value) ? Math.max(0, value) : 0;
+      const barHeight = maxValue > 0 ? (normalized / maxValue) * chartHeight : 0;
+      const y = height - paddingBottom - barHeight;
+      const dayLabel = entry.dayKey ? entry.dayKey.slice(8) : String(index + 1);
+      return [
+        `<rect x="${x}" y="${y}" width="${barWidth}" height="${barHeight}" rx="4" fill="${options.fill || "rgba(125, 183, 227, 0.88)"}" />`,
+        `<text x="${x + barWidth / 2}" y="${height - 5}" text-anchor="middle" font-size="9" fill="#6b8597">${dayLabel}</text>`
+      ].join("");
+    })
+    .join("");
+
+  return `${guides}${bars}`;
+}
+
+function setTrendDelta(node, direction, delta, options = {}) {
+  node.className = "trend-delta";
+  if (!Number.isFinite(delta)) {
+    node.textContent = "--";
+    node.classList.add("trend-delta--steady");
+    return;
+  }
+
+  const preferLower = !!options.preferLower;
+  let visualDirection = direction;
+  if (preferLower && direction === "up") {
+    visualDirection = "down";
+  } else if (preferLower && direction === "down") {
+    visualDirection = "up";
+  }
+
+  node.classList.add(`trend-delta--${visualDirection}`);
+  const unit = clean(options.unit) || "";
+  const sign = delta > 0 ? "+" : delta < 0 ? "" : "±";
+  node.textContent = `${sign}${delta}${unit ? ` ${unit}` : ""}`;
+}
+
+function renderCategoryTrendBars(categories) {
+  categoryTrendBars.innerHTML = "";
+
+  if (!Array.isArray(categories) || categories.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "muted";
+    empty.textContent = "Category mix will appear after more prompts are tracked.";
+    categoryTrendBars.appendChild(empty);
+    return;
+  }
+
+  categories.slice(0, 4).forEach((category) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "category-bar";
+    wrapper.innerHTML = `
+      <div class="category-bar__meta">
+        <span>${category.label}</span>
+        <span>${category.count} • ${category.percentage}%</span>
+      </div>
+      <div class="category-bar__track">
+        <div class="category-bar__fill" style="width: ${category.percentage}%"></div>
+      </div>
+    `;
+    categoryTrendBars.appendChild(wrapper);
+  });
+}
+
+function renderTrendDashboard(dashboard) {
+  trendWindowLabel.textContent = `${dashboard.days} days`;
+  trendActiveDays.textContent = `${dashboard.activeDays} active`;
+  trendActiveDays.className = `grade ${dashboard.activeDays > 0 ? "grade--b" : "grade--na"}`;
+
+  setTrendDelta(qualityTrendDelta, dashboard.qualityTrend.direction, dashboard.qualityTrend.delta, {
+    unit: "pts"
+  });
+  qualityTrendSummary.textContent = dashboard.qualityTrend.summary;
+
+  const qualityMarkup = buildLineChartMarkup(dashboard.qualitySeries, (entry) => entry.averageScore, {
+    maxValue: 100,
+    stroke: "#4b8fbe",
+    dotFill: "#215d8b"
+  });
+  if (qualityMarkup) {
+    qualityTrendChart.innerHTML = qualityMarkup;
+  } else {
+    renderEmptyTrendChart(qualityTrendChart, "Need more scored prompts");
+  }
+
+  setTrendDelta(warningTrendDelta, dashboard.warningTrend.direction, dashboard.warningTrend.delta, {
+    unit: "events",
+    preferLower: true
+  });
+  warningTrendSummary.textContent = dashboard.warningTrend.summary;
+
+  const warningMarkup = buildBarChartMarkup(
+    dashboard.warningSeries,
+    (entry) => entry.warningEventCount,
+    {
+      fill: "rgba(186, 47, 38, 0.68)"
+    }
+  );
+  if (warningMarkup) {
+    warningTrendChart.innerHTML = warningMarkup;
+  } else {
+    renderEmptyTrendChart(warningTrendChart, "No warning history yet");
+  }
+
+  trendTopCategory.textContent = dashboard.topCategory ? dashboard.topCategory.label : "--";
+  renderCategoryTrendBars(dashboard.categoryBreakdown);
+  trendRulesSummary.textContent = `Quality: ${dashboard.rules.qualityOverTime} Warnings: ${dashboard.rules.warningFrequency}`;
+}
+
 function renderAnalyticsSnapshot(rawState) {
   let snapshot = null;
   let dailySummary = null;
+  let trendDashboard = null;
 
   try {
     const analytics = getLearningAnalytics();
     snapshot = analytics.getSnapshot(rawState);
     dailySummary = analytics.buildDailySessionSummary(rawState);
+    trendDashboard = analytics.buildTrendDashboard(rawState);
   } catch (error) {
     analyticsPromptCount.textContent = "--";
     analyticsAverageScore.textContent = "--";
@@ -694,6 +923,20 @@ function renderAnalyticsSnapshot(rawState) {
     sessionSummaryStats.textContent = "";
     sessionCategoryList.innerHTML = "";
     sessionSuggestionList.innerHTML = "";
+    trendWindowLabel.textContent = "--";
+    trendActiveDays.textContent = "0 active";
+    trendActiveDays.className = "grade grade--na";
+    qualityTrendDelta.textContent = "--";
+    qualityTrendDelta.className = "trend-delta trend-delta--steady";
+    qualityTrendChart.innerHTML = "";
+    qualityTrendSummary.textContent = "";
+    warningTrendDelta.textContent = "--";
+    warningTrendDelta.className = "trend-delta trend-delta--steady";
+    warningTrendChart.innerHTML = "";
+    warningTrendSummary.textContent = "";
+    trendTopCategory.textContent = "--";
+    categoryTrendBars.innerHTML = "";
+    trendRulesSummary.textContent = "";
     return;
   }
 
@@ -724,6 +967,7 @@ function renderAnalyticsSnapshot(rawState) {
   analyticsMeta.textContent = metaParts.join(" | ") || "Stored locally for now. Future sync will build from this event history.";
 
   renderDailySessionSummary(dailySummary);
+  renderTrendDashboard(trendDashboard);
 }
 
 function renderList(target, items, emptyText) {

--- a/extension/shared/learningAnalytics.js
+++ b/extension/shared/learningAnalytics.js
@@ -5,6 +5,7 @@
   const DEFAULT_PLATFORM = "Unknown";
   const DEFAULT_SOURCE = "composer_submit";
   const DEFAULT_CATEGORY = "unclassified";
+  const DEFAULT_TREND_WINDOW_DAYS = 7;
   const CATEGORY_LABELS = {
     debugging: "Debugging",
     code_review: "Code Review",
@@ -128,6 +129,33 @@
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
+  }
+
+  function shiftDay(timestamp, offsetDays) {
+    const date = new Date(normalizeTimestamp(timestamp));
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + offsetDays);
+    return date.getTime();
+  }
+
+  function buildDayKeys(endTimestamp, days) {
+    const safeDays = Math.max(1, Math.min(30, asNonNegativeInteger(days) || DEFAULT_TREND_WINDOW_DAYS));
+    const keys = [];
+    for (let index = safeDays - 1; index >= 0; index -= 1) {
+      keys.push(buildDayKey(shiftDay(endTimestamp, -index)));
+    }
+    return keys;
+  }
+
+  function formatDayLabel(dayKey) {
+    const parsed = new Date(`${dayKey}T00:00:00`);
+    if (Number.isNaN(parsed.getTime())) {
+      return dayKey;
+    }
+    return parsed.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric"
+    });
   }
 
   function makeCountMap(rawMap, normalizeKey = (key) => clean(key)) {
@@ -510,6 +538,149 @@
     };
   }
 
+  function buildTrendDirection(firstValue, lastValue, options = {}) {
+    const threshold = Math.max(1, asNonNegativeInteger(options.threshold) || 5);
+    if (!Number.isFinite(firstValue) || !Number.isFinite(lastValue)) {
+      return "steady";
+    }
+
+    const delta = Math.round(lastValue - firstValue);
+    if (delta >= threshold) {
+      return "up";
+    }
+    if (delta <= -threshold) {
+      return "down";
+    }
+    return "steady";
+  }
+
+  function buildTrendSummaryLabel(metricLabel, direction, delta, options = {}) {
+    const preferLower = !!options.preferLower;
+    const unit = clean(options.unit) || "point";
+    const pluralUnit = clean(options.pluralUnit) || `${unit}s`;
+    if (!Number.isFinite(delta)) {
+      return `${metricLabel} trend needs more activity before it can be compared.`;
+    }
+    const absoluteDelta = Math.abs(delta);
+    const unitLabel = absoluteDelta === 1 ? unit : pluralUnit;
+
+    if (direction === "up") {
+      return preferLower
+        ? `${metricLabel} increased by ${absoluteDelta} ${unitLabel} across the visible window.`
+        : `${metricLabel} is improving by ${absoluteDelta} ${unitLabel} across the visible window.`;
+    }
+    if (direction === "down") {
+      return preferLower
+        ? `${metricLabel} improved by dropping ${absoluteDelta} ${unitLabel} across the visible window.`
+        : `${metricLabel} dropped by ${absoluteDelta} ${unitLabel} across the visible window.`;
+    }
+    return `${metricLabel} stayed roughly stable across the visible window.`;
+  }
+
+  function buildTrendDashboard(rawState, options = {}) {
+    const state = coerceState(rawState);
+    const endTimestamp = normalizeTimestamp(options.timestamp || options.now);
+    const days = Math.max(1, Math.min(30, asNonNegativeInteger(options.days) || DEFAULT_TREND_WINDOW_DAYS));
+    const dayKeys = buildDayKeys(endTimestamp, days);
+    const windowDaySet = new Set(dayKeys);
+    const filteredEvents = state.promptEvents.filter((event) => windowDaySet.has(event.dayKey));
+    const bucketByDay = dayKeys.reduce((accumulator, dayKey) => {
+      accumulator[dayKey] = [];
+      return accumulator;
+    }, {});
+
+    filteredEvents.forEach((event) => {
+      if (bucketByDay[event.dayKey]) {
+        bucketByDay[event.dayKey].push(event);
+      }
+    });
+
+    const qualitySeries = dayKeys.map((dayKey) => {
+      const events = bucketByDay[dayKey];
+      const scoredEvents = events.filter((event) => Number.isFinite(event.score));
+      const averageScore = scoredEvents.length > 0
+        ? Math.round(scoredEvents.reduce((sum, event) => sum + event.score, 0) / scoredEvents.length)
+        : null;
+
+      return {
+        dayKey,
+        label: formatDayLabel(dayKey),
+        totalPrompts: events.length,
+        averageScore
+      };
+    });
+
+    const warningSeries = dayKeys.map((dayKey) => {
+      const events = bucketByDay[dayKey];
+      const warningEventCount = events.filter((event) => event.warningCount > 0).length;
+      return {
+        dayKey,
+        label: formatDayLabel(dayKey),
+        totalPrompts: events.length,
+        warningEventCount,
+        warningRate: events.length > 0 ? Math.round((warningEventCount / events.length) * 100) : 0
+      };
+    });
+
+    const categorySummary = summarizePromptEvents(filteredEvents);
+    const categoryBreakdown = rankCountMap(
+      categorySummary.categoryCounts,
+      categorySummary.totalPrompts,
+      getCategoryLabel
+    );
+
+    const scoredTrendPoints = qualitySeries.filter((entry) => Number.isFinite(entry.averageScore));
+    const qualityFirst = scoredTrendPoints.length > 0 ? scoredTrendPoints[0].averageScore : null;
+    const qualityLast = scoredTrendPoints.length > 0 ? scoredTrendPoints[scoredTrendPoints.length - 1].averageScore : null;
+    const qualityDelta =
+      Number.isFinite(qualityFirst) && Number.isFinite(qualityLast)
+        ? Math.round(qualityLast - qualityFirst)
+        : null;
+    const qualityDirection = buildTrendDirection(qualityFirst, qualityLast, {
+      threshold: 5
+    });
+
+    const warningFirst = warningSeries.length > 0 ? warningSeries[0].warningEventCount : null;
+    const warningLast = warningSeries.length > 0 ? warningSeries[warningSeries.length - 1].warningEventCount : null;
+    const warningDelta =
+      Number.isFinite(warningFirst) && Number.isFinite(warningLast)
+        ? Math.round(warningLast - warningFirst)
+        : null;
+    const warningDirection = buildTrendDirection(warningFirst, warningLast, {
+      threshold: 1
+    });
+
+    return {
+      days,
+      totalPrompts: filteredEvents.length,
+      activeDays: qualitySeries.filter((entry) => entry.totalPrompts > 0).length,
+      qualitySeries,
+      warningSeries,
+      categoryBreakdown,
+      topCategory: categoryBreakdown[0] || null,
+      qualityTrend: {
+        direction: qualityDirection,
+        delta: qualityDelta,
+        summary: buildTrendSummaryLabel("Prompt quality", qualityDirection, qualityDelta, {
+          unit: "point"
+        })
+      },
+      warningTrend: {
+        direction: warningDirection,
+        delta: warningDelta,
+        summary: buildTrendSummaryLabel("Warning frequency", warningDirection, warningDelta, {
+          preferLower: true,
+          unit: "event"
+        })
+      },
+      rules: {
+        qualityOverTime: "Average prompt score per day across scored prompt events.",
+        warningFrequency: "Count of prompt events per day that triggered one or more warnings.",
+        categoryBreakdown: "Prompt category mix across the visible local history window."
+      }
+    };
+  }
+
   function buildFutureSyncPayload(rawState, options = {}) {
     const state = coerceState(rawState);
     return {
@@ -606,6 +777,7 @@
     STORAGE_KEY,
     SCHEMA_VERSION,
     MAX_PROMPT_EVENTS,
+    DEFAULT_TREND_WINDOW_DAYS,
     DEFAULT_CATEGORY,
     CATEGORY_LABELS,
     createEmptyState,
@@ -614,6 +786,7 @@
     coerceState,
     appendPromptEvent,
     buildDailySessionSummary,
+    buildTrendDashboard,
     buildFutureSyncPayload,
     readState,
     writeState,

--- a/scripts/test-learning-analytics.mjs
+++ b/scripts/test-learning-analytics.mjs
@@ -131,4 +131,30 @@ assert.ok(
   "daily summary headline should be readable for end users"
 );
 
+const trendDashboard = analytics.buildTrendDashboard(mockStorage.read(), {
+  timestamp: Date.parse("2026-03-13T23:59:00Z"),
+  days: 3
+});
+
+assert.equal(trendDashboard.days, 3, "trend dashboard should respect the requested window size");
+assert.equal(trendDashboard.activeDays, 2, "trend dashboard should count active days with prompts");
+assert.equal(trendDashboard.qualitySeries.length, 3, "quality trend should include one point per day in the window");
+assert.equal(
+  trendDashboard.qualitySeries[2].averageScore,
+  65,
+  "quality trend should use the daily average score for the most recent day"
+);
+assert.equal(
+  trendDashboard.warningSeries[2].warningEventCount,
+  2,
+  "warning trend should count prompt events that emitted warnings"
+);
+assert.equal(trendDashboard.topCategory.key, "debugging", "trend dashboard should rank prompt categories");
+assert.equal(trendDashboard.qualityTrend.direction, "down", "quality trend should compare first vs last scored day");
+assert.equal(trendDashboard.warningTrend.direction, "up", "warning trend should compare first vs last warning count");
+assert.ok(
+  trendDashboard.rules.qualityOverTime.includes("Average prompt score per day"),
+  "trend dashboard should expose explainable calculation rules"
+);
+
 console.log("Learning analytics checks passed.");


### PR DESCRIPTION
## Summary
- add a local trend dashboard for learning analytics in the extension popup
- show quality over time, warning frequency, and prompt category mix using shared analytics rules
- document the trend rules and extend analytics smoke coverage

## Testing
- node scripts/validate-extension.mjs
- node scripts/test-prompt-quality-engine.mjs
- node scripts/test-prompt-linter.mjs
- node scripts/test-learning-analytics.mjs
- python3 -m mkdocs build --strict
- find extension -name "*.js" -print0 | xargs -0 -n1 node --check

Refs #16