### PR TITLE
fix(builder): keep launcher attached during app rerenders

### DIFF
--- a/extension/content/quickBuilder.js
+++ b/extension/content/quickBuilder.js
@@ -944,10 +944,32 @@
     };
   }
 
+  function ensureUiAttached() {
+    if (!state.refs || !document.body) {
+      return false;
+    }
+
+    let reattached = false;
+
+    if (state.refs.launcher && !document.contains(state.refs.launcher)) {
+      document.body.appendChild(state.refs.launcher);
+      reattached = true;
+    }
+
+    if (state.refs.panel && !document.contains(state.refs.panel)) {
+      document.body.appendChild(state.refs.panel);
+      reattached = true;
+    }
+
+    return reattached;
+  }
+
   function updateLauncherPosition() {
     if (!state.refs) {
       return;
     }
+
+    ensureUiAttached();
 
     const platform = detectPlatform();
     const input = findPromptInput(platform);
@@ -1014,6 +1036,8 @@
     if (!state.refs) {
       return;
     }
+
+    ensureUiAttached();
 
     state.panelOpen = typeof open === "boolean" ? open : !state.panelOpen;
     state.refs.panel.classList.toggle("ai-coach-builder__hidden", !state.panelOpen);
@@ -1189,6 +1213,7 @@
     window.addEventListener("resize", scheduleLayoutUpdate, { passive: true });
     window.addEventListener("scroll", scheduleLayoutUpdate, { passive: true, capture: true });
     document.addEventListener("focusin", scheduleLayoutUpdate, true);
+    document.addEventListener("visibilitychange", scheduleLayoutUpdate, true);
   }
 
   function isShortcutToggleEvent(event) {


### PR DESCRIPTION
## Summary
- keep the in-page Prompt Builder launcher and panel attached during host app rerenders
- reattach the nodes before layout/panel updates if a SPA removed them from the DOM
- refresh placement after tab visibility changes as well as focus, scroll, and resize events

## Why
Sites like ChatGPT can rerender large parts of the page, which can detach the injected launcher from `document.body`. Before this fix, the launcher could disappear permanently until the page reloaded.

## Validation
- `node --check extension/content/quickBuilder.js`
- `node scripts/validate-extension.mjs`
